### PR TITLE
Fix sep10 test

### DIFF
--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -196,7 +196,6 @@ describe("SEP10", () => {
 
   describe("signers support", () => {
     afterAll(async () => {
-      console.log("DESTROY ALL FRIENDS");
       await friendbot.destroyAllFriends();
     });
 

--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -215,7 +215,10 @@ describe("SEP10", () => {
       })
         .addOperation(
           StellarSDK.Operation.setOptions({
-            masterWeight: 0
+            masterWeight: 0,
+            lowThreshold: 1,
+            medThreshold: 1,
+            highThreshold: 1
           })
         )
         .setTimeout(30)


### PR DESCRIPTION
There was a problem with the test `fails for an account that can't sign for itself` in which we set masterWeight to 0 but the medium threshold was also 0 so it still succeeded.  