### PR TITLE
Fix timeouts of API call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
   && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
 
 RUN apt-get update && apt-get install -y \
-  google-chrome-stable=79.0.3945.130-1 \
+  google-chrome-stable=80.0.3987.87-1  \
   nodejs \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install chromedriver
-RUN curl https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip -o /usr/local/bin/chromedriver
+RUN curl https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip -o /usr/local/bin/chromedriver
 RUN chmod +x /usr/local/bin/chromedriver
 
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -35,12 +35,7 @@ $ docker run  -p 3000:3000  transfer-server-validator
 ### Running locally
 
 ```
-# Run the server
-$ yarn
-$ yarn start
-
-# Run the client
-$ cd client
+# Run the server+client
 $ yarn
 $ yarn start
 ```

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,7 +19,6 @@ function App() {
       try {
         const evtSource = new EventSource(`/run?domain=${domain}`);
         evtSource.addEventListener("message", event => {
-          console.log("Message", event.data);
           const message = JSON.parse(event.data);
           if (message.loadingMessage) {
             setLoadingMessage(message.loadingMessage);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,20 +8,43 @@ import ResultSet from "./ResultSet";
 function App() {
   const [results, setResults] = useState(null);
   const [isLoading, setLoading] = useState(false);
-  const runValidation = useCallback(async domain => {
-    setLoading(true);
-    setResults(null);
-    const response = await fetch("/run?domain=" + domain);
-    //todo error handle
-    const json = await response.json();
-    setResults(json);
-    setLoading(false);
-  }, []);
+  const [loadingMessage, setLoadingMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState(null);
+  const runValidation = useCallback(
+    async domain => {
+      setLoading(true);
+      setResults(null);
+      setErrorMessage(null);
+      try {
+        const evtSource = new EventSource(`/run?domain=${domain}`);
+        evtSource.addEventListener("message", event => {
+          console.log("Message", event.data);
+          const message = JSON.parse(event.data);
+          if (message.loadingMessage) {
+            setLoadingMessage(message.loadingMessage);
+          } else if (message.results) {
+            setResults(message.results);
+            setLoading(false);
+          }
+        });
+
+        evtSource.onerror = e => {
+          console.log(e);
+          setErrorMessage("Something went wrong");
+        };
+      } catch (e) {
+        console.log(e);
+        setErrorMessage("Something went wrong");
+        setLoading(false);
+      }
+    },
+    [setLoading, setLoadingMessage, setResults, setErrorMessage]
+  );
 
   return (
     <div className="App">
       <DomainInput onValidateClick={runValidation} isLoading={isLoading} />
-      <Loading active={isLoading} />
+      <Loading active={isLoading} message={loadingMessage} />
       <ResultSet results={results} />
     </div>
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,7 +17,10 @@ function App() {
       setResults(null);
       setErrorMessage(null);
       try {
-        const evtSource = new EventSource(`/run?domain=${domain}`);
+        console.log("Lets re-ask");
+        const evtSource = new EventSource(
+          `${process.env.REACT_APP_API_HOST}/run?domain=${domain}`
+        );
         evtSource.addEventListener("message", event => {
           const message = JSON.parse(event.data);
           if (message.loadingMessage) {
@@ -30,6 +33,7 @@ function App() {
 
         evtSource.onerror = e => {
           console.log(e);
+          evtSource.close();
           setErrorMessage("Something went wrong");
         };
       } catch (e) {

--- a/client/src/Loading.js
+++ b/client/src/Loading.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function loading({ active }) {
+export default function loading({ active, message }) {
   if (!active) return null;
-  return <div>Loading...</div>;
+  return <div>{message || "Loading..."}</div>;
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "jest -i --verbose --runInBand",
     "server:dev": "PORT=3001 nodemon server/api.js",
-    "start": "node server/api.js",
+    "start": "concurrently \"cd client && REACT_APP_API_HOST=http://localhost:3001 yarn start\" \"PORT=3001 npm run server:dev\"",
     "heroku-postbuild": "cd client && yarn && yarn run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.7.6",
     "babel-jest": "^24.9.0",
     "chromedriver": "^79.0.0",
+    "compression": "^1.7.4",
     "concurrently": "^5.0.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/api.js
+++ b/server/api.js
@@ -4,7 +4,7 @@ const path = require("path");
 const listTests = require("./list-tests");
 const runTests = require("./run-tests");
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 const app = express();
 app.use(cors());
 app.options("*", cors());
@@ -17,4 +17,4 @@ app.get("*", (req, res) => {
   res.sendFile(path.join(__dirname + "/../client/build/index.html"));
 });
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+app.listen(port, () => console.log(`Validator API listening on port ${port}!`));

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,5 +1,23 @@
 const { spawn } = require("child_process");
-module.exports = (req, res) => {
+
+module.exports = async (req, res) => {
+  // Set up server-sent events
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*"
+  });
+
+  let i = 0;
+  const sendLoadingMessage = _ => {
+    const message = ["Running Tests", "Still running tests", "Still going"][
+      i++ % 3
+    ];
+    res.write(`data: ${JSON.stringify({ loadingMessage: message })}\n\n`);
+  };
+  sendLoadingMessage();
+  const timer = setInterval(sendLoadingMessage, 5000);
   const domain = req.query.domain;
   const env = { ...process.env };
   env.DOMAIN = domain;
@@ -29,8 +47,8 @@ module.exports = (req, res) => {
         );
       });
     });
-    res.send(results);
-    debugger;
+    clearInterval(timer);
+    res.write(`data: ${JSON.stringify({ results })}\n\n`);
     console.log(`child process exited with code ${code}`);
   });
 };


### PR DESCRIPTION
We were using one single API request to run all the unit tests which would quite obviously time-out now that we have lots of tests.  This changes it to use ServerSent events which will let us run as long as we want, as well as set the stage for sending back incremental updates.  Currently it just sends back "still working" updates which is also helpful.

This is already deployed but i had some things to fix to make sure it still worked in development.

This also adds a single command to run the whole server+client in development.