### PR TITLE
URLEncode the xdr for the urlencoded test

### DIFF
--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -104,7 +104,7 @@ describe("SEP10", () => {
           headers: {
             "Content-Type": "application/x-www-form-urlencoded"
           },
-          body: "transaction=" + tx.toXDR()
+          body: "transaction=" + encodeURIComponent(tx.toXDR())
         });
         let tokenJson = await resp.json();
         expect(tokenJson.error).toBeFalsy();


### PR DESCRIPTION
The test was broken, we were passing a raw string as a urlencoded parameter so the `+` was breaking the xdr.  This fixes that.