### PR TITLE
Remove trailing slashes from toml file, add them in the tests

### DIFF
--- a/cases/deposit.test.js
+++ b/cases/deposit.test.js
@@ -31,7 +31,7 @@ describe("Deposit", () => {
       params.getHeaders()
     );
     const response = await fetch(
-      toml.TRANSFER_SERVER + "transactions/deposit/interactive",
+      toml.TRANSFER_SERVER + "/transactions/deposit/interactive",
       {
         headers: authenticate ? authenticatedHeaders : params.getHeaders(),
         method: "POST",
@@ -53,7 +53,7 @@ describe("Deposit", () => {
       throw "Invalid TOML formatting";
     }
 
-    const infoResponse = await fetch(toml.TRANSFER_SERVER + "info", {
+    const infoResponse = await fetch(toml.TRANSFER_SERVER + "/info", {
       headers: {
         Origin: "https://www.website.com"
       }

--- a/cases/info.test.js
+++ b/cases/info.test.js
@@ -19,7 +19,7 @@ describe("Info", () => {
   });
 
   it("has CORS on the info endpoint", async () => {
-    const response = await fetch(toml.TRANSFER_SERVER + "info", {
+    const response = await fetch(toml.TRANSFER_SERVER + "/info", {
       headers: {
         Origin: "https://www.website.com"
       }
@@ -31,7 +31,7 @@ describe("Info", () => {
     let json;
 
     beforeAll(async () => {
-      const response = await fetch(toml.TRANSFER_SERVER + "info", {
+      const response = await fetch(toml.TRANSFER_SERVER + "/info", {
         headers: {
           Origin: "https://www.website.com"
         }

--- a/cases/transaction.test.js
+++ b/cases/transaction.test.js
@@ -27,7 +27,7 @@ describe("Transaction", () => {
       params.getHeaders()
     );
     const response = await fetch(
-      toml.TRANSFER_SERVER + "transactions/deposit/interactive",
+      toml.TRANSFER_SERVER + "/transactions/deposit/interactive",
       {
         headers: authenticate ? authenticatedHeaders : params.getHeaders(),
         method: "POST",
@@ -44,7 +44,7 @@ describe("Transaction", () => {
   beforeAll(async () => {
     toml = await getTomlFile(domain);
     jwt = await getSep10Token(domain, keyPair);
-    const infoResponse = await fetch(toml.TRANSFER_SERVER + "info", {
+    const infoResponse = await fetch(toml.TRANSFER_SERVER + "/info", {
       headers: {
         Origin: "https://www.website.com"
       }
@@ -64,7 +64,7 @@ describe("Transaction", () => {
       true
     );
     const response = await fetch(
-      toml.TRANSFER_SERVER + "transaction?id=" + json.id,
+      toml.TRANSFER_SERVER + "/transaction?id=" + json.id,
       {
         headers: {
           Authorization: `Bearer ${jwt}`
@@ -80,7 +80,7 @@ describe("Transaction", () => {
   it("returns a proper error for a non-existing transaction", async () => {
     const response = await fetch(
       toml.TRANSFER_SERVER +
-        "transaction?id=1277bd18-a2bd-4acd-9a87-2f541c7b8933",
+        "/transaction?id=1277bd18-a2bd-4acd-9a87-2f541c7b8933",
       {
         headers: {
           Authorization: `Bearer ${jwt}`

--- a/cases/util/getTomlFile.js
+++ b/cases/util/getTomlFile.js
@@ -5,12 +5,13 @@ export default async function(domain) {
   let response = await fetch(domain + ".well-known/stellar.toml");
   const text = await response.text();
   const toml = TOML.parse(text);
-  if (toml.WEB_AUTH_ENDPOINT[toml.WEB_AUTH_ENDPOINT.length - 1] !== "/") {
-      toml.WEB_AUTH_ENDPOINT += "/";
-    }    
-  if (toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] !== "/") {
-      toml.TRANSFER_SERVER += "/";
-    }
+  // Remove trailing slashes for consistency in building URLs
+  if (toml.WEB_AUTH_ENDPOINT[toml.WEB_AUTH_ENDPOINT.length - 1] === "/") {
+    toml.WEB_AUTH_ENDPOINT = toml.WEB_AUTH_ENDPOINT.slice(0, -1);
+  }
+  if (toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] === "/") {
+    toml.TRANSFER_SERVER = toml.TRANSFER_SERVER.slice(0, -1);
+  }
   expect(toml).toBeDefined();
   return toml;
 }

--- a/cases/util/getTomlFile.js
+++ b/cases/util/getTomlFile.js
@@ -6,9 +6,6 @@ export default async function(domain) {
   const text = await response.text();
   const toml = TOML.parse(text);
   // Remove trailing slashes for consistency in building URLs
-  if (toml.WEB_AUTH_ENDPOINT[toml.WEB_AUTH_ENDPOINT.length - 1] === "/") {
-    toml.WEB_AUTH_ENDPOINT = toml.WEB_AUTH_ENDPOINT.slice(0, -1);
-  }
   if (toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] === "/") {
     toml.TRANSFER_SERVER = toml.TRANSFER_SERVER.slice(0, -1);
   }


### PR DESCRIPTION
A previous pull request added trailing slashes to the web auth endpoint which caused problems since the url `/auth/` is not the same as `/auth`.  Instead of adding a trailing slash for the TRANSFER_SERVER we remove it, and add it in the paths.  Also we don't touch the WEB_AUTH_ENDPOINT, since we don't actually build any URLs  with that, we just GET and POST to it, so its up to the anchor to put the correct format in their toml