### PR TITLE
Fix problem where the deposit interactive test wouldn't finish

### DIFF
--- a/cases/deposit.test.js
+++ b/cases/deposit.test.js
@@ -113,8 +113,11 @@ describe("Deposit", () => {
       expect(status).toEqual(200);
     });
 
-    it.skip("can load get through the interactive flow", async done => {
-      const window = await openObservableWindow(interactiveURL);
+    it("can load get through the interactive flow", async done => {
+      const builder = new URL(interactiveURL);
+      builder.searchParams.set("callback", "postMessage");
+      console.log(builder.toString(), "Interactive URL");
+      const window = await openObservableWindow(builder.toString());
       // Lets wait until the whole flow finishes by observering for
       // a postMessage awaiting user transfer start
       window.observePostMessage(message => {

--- a/cases/deposit.test.js
+++ b/cases/deposit.test.js
@@ -116,7 +116,6 @@ describe("Deposit", () => {
     it("can load get through the interactive flow", async done => {
       const builder = new URL(interactiveURL);
       builder.searchParams.set("callback", "postMessage");
-      console.log(builder.toString(), "Interactive URL");
       const window = await openObservableWindow(builder.toString());
       // Lets wait until the whole flow finishes by observering for
       // a postMessage awaiting user transfer start

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -31,7 +31,6 @@ export const openObservableWindow = async url => {
       delete window.__LAST_POST_MESSAGE__;
       return lastMessage;
     });
-
     await driver.switchTo().window(handles[1]);
     if (lastMessage) {
       observers.forEach(o => o(lastMessage));

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -14,9 +14,7 @@ export const waitForLoad = async () => {
  * @param {string} url
  */
 export const openObservableWindow = async url => {
-  await driver.get(
-    `data:text/html,<script>window.open("${url}", 'newwindow')</script>`
-  );
+  await driver.get(`data:text/html,<script>window.open("${url}")</script>`);
   const handles = await driver.getAllWindowHandles();
   await driver.switchTo().window(handles[0]);
   await driver.executeScript(() => {

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -19,7 +19,6 @@ export const openObservableWindow = async url => {
   await driver.switchTo().window(handles[0]);
   await driver.executeScript(() => {
     window.addEventListener("message", e => {
-      console.log("MEssage", e);
       window.__LAST_POST_MESSAGE__ = e.data;
     });
   });
@@ -37,7 +36,7 @@ export const openObservableWindow = async url => {
     if (lastMessage) {
       observers.forEach(o => o(lastMessage));
     }
-  }, 2000);
+  }, 1000);
 
   return {
     observePostMessage: cb => {

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -14,11 +14,14 @@ export const waitForLoad = async () => {
  * @param {string} url
  */
 export const openObservableWindow = async url => {
-  await driver.get(`data:text/html,<script>window.open("${url}")</script>`);
+  await driver.get(
+    `data:text/html,<script>window.open("${url}", 'newwindow')</script>`
+  );
   const handles = await driver.getAllWindowHandles();
   await driver.switchTo().window(handles[0]);
   await driver.executeScript(() => {
     window.addEventListener("message", e => {
+      console.log("MEssage", e);
       window.__LAST_POST_MESSAGE__ = e.data;
     });
   });
@@ -31,11 +34,12 @@ export const openObservableWindow = async url => {
       delete window.__LAST_POST_MESSAGE__;
       return lastMessage;
     });
+
     await driver.switchTo().window(handles[1]);
     if (lastMessage) {
       observers.forEach(o => o(lastMessage));
     }
-  }, 1000);
+  }, 2000);
 
   return {
     observePostMessage: cb => {

--- a/cases/util/deposit.js
+++ b/cases/util/deposit.js
@@ -1,8 +1,0 @@
-import { fetch } from "./fetchShim";
-import getTomlFile from "./getTomlFile";
-import getSep10Token from "./sep10";
-export default async function(domain, keyPair) {
-  const toml = await getTomlFile(domain);
-  const jwt = await getSep10Token(domain, keyPair);
-  return toml;
-}


### PR DESCRIPTION
postMessage detection stopped working because we need to append callback=postMessage rather than expecting that behavior by default