### PR TITLE
Clean up app.tsx, allow re-runs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,60 +3,57 @@ import React, { useCallback, useState, useEffect } from "react";
 import "./App.css";
 import ErrorMessage from "./ErrorMessage";
 import TestList from "./TestList";
-import { TestResultSet, TestStatus } from "./TestResults";
+import { TestResultSet, TestStatus, makeTestResultSet } from "./TestResults";
 import runTest from "./api/runTest";
 import s from "./App.module.css";
 
-type ResultList = TestResultSet[];
 function App() {
   const [errorMessage, setErrorMessage] = useState<String | null>(null);
-  const [testList, setTestList] = useState<ResultList>([]);
+  // All tests available from the server
+  const [availableTests, setAvailableTests] = useState<string[]>([]);
+  // Current (pending) test runs
+  const [testList, setTestList] = useState<TestResultSet[]>([]);
   const [busy, setBusy] = useState<boolean>(false);
   const [domain, setDomain] = useState("https://testanchor.stellar.org");
   const [runOptionalTests, setRunOptionalTests] = useState<boolean>(
-    Boolean(parseInt(process.env.RUN_OPTIONAL_TESTS || "0")) || false
+    Boolean(parseInt(process.env.RUN_OPTIONAL_TESTS || "0")) || false,
   );
 
   useEffect(() => {
     const fetchList = async () => {
       const res = await fetch("/list");
-      const list: string[] = await res.json();
-      setTestList(
-        list.map((name) => {
-          let status = TestStatus.PENDING;
-          if (name.includes(".optional")) {
-            status = TestStatus.SKIPPED
-          };
-          return {
-            name: name,
-            results: [],
-            status: status,
-            numFailedTests: 0,
-            numPassedTests: 0,
-          };
-        }),
-      );
+      const testNames: string[] = await res.json();
+      setAvailableTests(testNames);
     };
     fetchList();
   }, []);
 
+  const resetTests = useCallback(() => {
+    setTestList(availableTests.map(makeTestResultSet));
+  }, [availableTests]);
+  useEffect(resetTests, [availableTests]);
+
   useEffect(() => {
     const changeOptionalTestStatuses = () => {
-      setTestList(testList.map((test) => {
-        let opStatus = runOptionalTests ? TestStatus.PENDING : TestStatus.SKIPPED;
-        if (test.name.includes("optional")) {
-          test.status = opStatus;
-        };
-        return test;
-      }));
+      setTestList((previousTestList) => {
+        return previousTestList.map((test) => {
+          let opStatus = runOptionalTests
+            ? TestStatus.PENDING
+            : TestStatus.SKIPPED;
+          if (test.name.includes("optional")) {
+            test.status = opStatus;
+          }
+          return test;
+        });
+      });
     };
-    changeOptionalTestStatuses()
-  // eslint-disable-next-line
+    changeOptionalTestStatuses();
   }, [runOptionalTests]);
 
   const runTests = useCallback(
     async (_) => {
       try {
+        resetTests();
         setBusy(true);
         var nextTest: TestResultSet | undefined;
         while (
@@ -75,7 +72,7 @@ function App() {
       }
       setBusy(false);
     },
-    [testList, domain],
+    [testList, domain, resetTests],
   );
 
   return (
@@ -88,11 +85,7 @@ function App() {
           placeholder="home_domain"
           onChange={(e) => setDomain(e.target.value)}
         ></input>
-        <button
-          className={s.ValidateButton}
-          onClick={runTests}
-          disabled={busy}
-        >
+        <button className={s.ValidateButton} onClick={runTests} disabled={busy}>
           {busy ? "Running..." : "Run tests"}
         </button>
       </div>

--- a/client/src/TestResults.ts
+++ b/client/src/TestResults.ts
@@ -3,7 +3,7 @@ export enum TestStatus {
   FAILURE = "Failure",
   PENDING = "Pending",
   SKIPPED = "Skipped",
-  RUNNING = "Running"
+  RUNNING = "Running",
 }
 
 export interface TestResult {
@@ -16,4 +16,18 @@ export interface TestResultSet {
   status: TestStatus;
   numFailedTests: number;
   numPassedTests: number;
+}
+
+export function makeTestResultSet(name: string): TestResultSet {
+  let status = TestStatus.PENDING;
+  if (name.includes(".optional")) {
+    status = TestStatus.SKIPPED;
+  }
+  return {
+    name: name,
+    results: [],
+    status: status,
+    numFailedTests: 0,
+    numPassedTests: 0,
+  };
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nodemon": "^2.0.2",
     "selenium-webdriver": "^4.0.0-alpha.5",
     "stellar-sdk": "^3.3.0",
+    "stmux": "^1.8.0",
     "toml": "^3.0.0"
   },
   "jest": {


### PR DESCRIPTION
Currently if you try to re-run the tests, it won't because all the tests are already succeeded.  This will reset the state of all the tests to pending when you try to re-run.

It also stores the available tests from the server as strings, instead of as full test suites so we can easily recreate the acutal test suites.
It pulls some of the json generation into a separate file to make things more obvious and less cluttered.
It uses functional updates for the setTestList call so we can remove the lint-ignore that may have had weird effects