### PR TITLE
End-to-End Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 reports
 junit.xml
 .idea
+results.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Test suite for validating services support for SEP24.
 
 ```
 $ yarn
-$ DOMAIN=https://stellar-anchor-server.herokuapp.com npx jest
+$ DOMAIN=https://testanchor.stellar.org npx jest
 ```
 
 ### Running a specific test
@@ -89,6 +89,11 @@ Any form field that is required should have a `test-value` attribute which is
 set to a valid value for that field. For example an email field would look like
 `<input type='text' id='email_address' test-value='dummyaddress2342@gmail.com' />`.
 The number can be randomized at render time to avoid reuse.
+
+Make sure the `test-value` for the deposit's 'Amount' field is greater than the
+`test-value` for the withdraw's 'Amount' field _plus_ the fee that will be
+charged for the deposit transaction. If this isn't the case, submitting the
+withdraw transaction to the stellar network will fail due to insufficient funds.
 
 An example of doing this using Polaris's form stack can be seen
 [here](https://github.com/stellar/django-polaris/blob/fd5900d68fec6b0e31ce720262e8d787fcbf8aac/example/server/forms.py#L10,L15)

--- a/cases/deposit.test.js
+++ b/cases/deposit.test.js
@@ -1,12 +1,8 @@
-/**
- * @jest-environment ./cases/environment.js
- */
 import { fetch } from "./util/fetchShim";
 import getSep10Token from "./util/sep10";
 import StellarSDK from "stellar-sdk";
 import getTomlFile from "./util/getTomlFile";
-import { getTransactionBy } from "./util/transactions";
-import { createTransaction, doInteractiveFlow } from "./util/interactive";
+import { createTransaction } from "./util/interactive";
 const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
 const keyPair = StellarSDK.Keypair.random();
@@ -98,23 +94,5 @@ describe("Deposit", () => {
     expect(json.id).toEqual(expect.any(String));
     expect(() => new global.URL(interactiveURL)).not.toThrow();
     expect(status).toEqual(200);
-  });
-
-  describe("happy path", () => {
-    it("can load get through the interactive flow", async () => {
-      let transactionId = await doInteractiveFlow({
-        currency: enabledCurrency,
-        account: keyPair.publicKey(),
-        jwt: jwt,
-        toml: toml,
-        isDeposit: true,
-      });
-      await getTransactionBy({
-        iden: "id",
-        value: transactionId,
-        toml: toml,
-        jwt: jwt,
-      });
-    });
   });
 });

--- a/cases/interactive-flows.optional.test.js
+++ b/cases/interactive-flows.optional.test.js
@@ -25,14 +25,26 @@ let issuerAccount;
 let asset;
 let account;
 
+function sleep(interval) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, interval);
+  });
+}
+
+/*
+ ** waitUntilTruthy() and waitUntilTransactionComplete() block the test
+ ** they are called from until their condition is met. This makes the
+ ** tests in this file run serially. For example, the 'Withdraw Flow's
+ ** 'can complete interactive flow' is blocked until depositTransactionJSON
+ ** is defined, signaling to the withdraw test that the deposit was
+ ** completed.
+ */
 function waitUntilTruthy(valObj, timeAllowed, interval) {
   return new Promise(async (resolve, reject) => {
     await new Promise(async (resolve) => {
       let timePassed = 0;
       while (!valObj.val && timePassed < timeAllowed) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, interval);
-        });
+        await sleep(interval);
         timePassed += interval;
       }
       resolve();
@@ -51,9 +63,7 @@ function waitUntilTransactionComplete(transactionId, timeAllowed, interval) {
       let respJSON;
       let timePassed = 0;
       while (timePassed < timeAllowed) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, interval);
-        });
+        await sleep(interval);
         timePassed += interval;
         let transactionResp = await fetch(
           toml.TRANSFER_SERVER + `/transaction?id=${transactionId}`,

--- a/cases/interactive-flows.optional.test.js
+++ b/cases/interactive-flows.optional.test.js
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment ./cases/environment.js
+ */
+import { fetch } from "./util/fetchShim";
+import getSep10Token from "./util/sep10";
+import StellarSDK from "stellar-sdk";
+import getTomlFile from "./util/getTomlFile";
+import { getTransactionBy } from "./util/transactions";
+import { doInteractiveFlow } from "./util/interactive";
+const urlBuilder = new URL(process.env.DOMAIN);
+const url = urlBuilder.toString();
+const keyPair = StellarSDK.Keypair.random();
+const horizonURL = "https://horizon-testnet.stellar.org";
+const server = new StellarSDK.Server(horizonURL);
+
+jest.setTimeout(180000);
+
+let infoJSON;
+let enabledCurrency;
+let jwt;
+let toml;
+let currencyInfo;
+let issuerAccount;
+let distributionAccount;
+let asset;
+let account;
+
+beforeAll(async () => {
+  await fetch(`https://friendbot.stellar.org?addr=${keyPair.publicKey()}`);
+  try {
+    toml = await getTomlFile(url);
+  } catch (e) {
+    throw "Invalid TOML formatting";
+  }
+
+  const infoResponse = await fetch(toml.TRANSFER_SERVER + "/info", {
+    headers: {
+      Origin: "https://www.website.com",
+    },
+  });
+  infoJSON = await infoResponse.json();
+  const currencies = Object.keys(infoJSON.withdraw);
+  // Note that we're only testing the first asset found to be enabled
+  enabledCurrency = currencies.find(
+    (currency) => infoJSON.withdraw[currency].enabled,
+  );
+  jwt = await getSep10Token(url, keyPair);
+
+  // Get info for interactive tests
+  currencyInfo = toml.CURRENCIES.find((obj) => obj.code === enabledCurrency);
+  issuerAccount = currencyInfo.issuer;
+  asset = new StellarSDK.Asset(enabledCurrency, issuerAccount);
+  account = await server.loadAccount(keyPair.publicKey());
+
+  // Establish trustline
+  let transaction = new StellarSDK.TransactionBuilder(account, {
+    fee: StellarSDK.BASE_FEE,
+    networkPassphrase: "Test SDF Network ; September 2015",
+  })
+    .addOperation(
+      StellarSDK.Operation.changeTrust({
+        asset: asset,
+        source: keyPair.publicKey(),
+      }),
+    )
+    .setTimeout(30)
+    .build();
+  transaction.sign(keyPair);
+
+  try {
+    await server.submitTransaction(transaction);
+  } catch (e) {
+    console.log(e);
+  }
+});
+
+describe("Deposit Flow", () => {
+  let transactionId;
+  let transactionJSON;
+  it("can complete the interactive flow", async () => {
+    transactionId = await doInteractiveFlow({
+      currency: enabledCurrency,
+      account: keyPair.publicKey(),
+      jwt: jwt,
+      toml: toml,
+      isDeposit: true,
+    });
+    let transactionRespJSON = await getTransactionBy({
+      iden: "id",
+      value: transactionId,
+      toml: toml,
+      jwt: jwt,
+    });
+    transactionJSON = transactionRespJSON.transaction;
+  });
+
+  it("pending transactions are completed on testnet", async () => {
+    // Wait for interactive flow to complete
+    await new Promise(async (resolve) => {
+      let timePassed = 0;
+      while (!transactionJSON && timePassed < 10000) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1000);
+        });
+        timePassed += 500;
+      }
+      resolve();
+    });
+    expect(transactionJSON).not.toEqual(undefined);
+
+    // Poll /transaction endpoint until deposit is marked as complete
+    let isComplete = false;
+    await new Promise(async (resolve) => {
+      let timePassed = 0;
+      while (!isComplete && timePassed < 50000) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2000);
+        });
+        timePassed += 2000;
+        let transactionResp = await fetch(
+          toml.TRANSFER_SERVER + `/transaction?id=${transactionId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${jwt}`,
+            },
+          },
+        );
+        let transactionRespJSON = await transactionResp.json();
+        if (transactionRespJSON.transaction.status === "completed") {
+          isComplete = true;
+        }
+      }
+      resolve();
+    });
+    expect(isComplete).toBeTruthy();
+  });
+});
+
+describe("Withdraw Flow", () => {
+  let transactionId;
+  let transactionJSON;
+  it("can complete interactive flow", async () => {
+    transactionId = await doInteractiveFlow({
+      currency: enabledCurrency,
+      account: keyPair.publicKey(),
+      jwt: jwt,
+      toml: toml,
+      isDeposit: false,
+    });
+    let transactionRespJSON = await getTransactionBy({
+      iden: "id",
+      value: transactionId,
+      expectStatus: 200,
+      toml: toml,
+      jwt: jwt,
+    });
+    transactionJSON = transactionRespJSON.transaction;
+  });
+
+  it("marks transaction as complete after submission", async () => {
+    // Wait for transactionJSON to be defined
+    await new Promise(async (resolve) => {
+      let timePassed = 0;
+      while (!transactionJSON && timePassed < 10000) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1000);
+        });
+        timePassed += 500;
+      }
+      resolve();
+    });
+    expect(transactionJSON).not.toEqual(undefined);
+
+    const distributionAccount = transactionJSON.withdraw_anchor_account;
+
+    let transaction = new StellarSDK.TransactionBuilder(account, {
+      fee: StellarSDK.BASE_FEE,
+      networkPassphrase: "Test SDF Network ; September 2015",
+    })
+      .addOperation(
+        StellarSDK.Operation.payment({
+          destination: distributionAccount,
+          asset: asset,
+          amount: transactionJSON.amount_in,
+        }),
+      )
+      .addMemo(StellarSDK.Memo.hash(transactionJSON.withdraw_memo))
+      .setTimeout(30)
+      .build();
+    transaction.sign(keyPair);
+    try {
+      let submitResponse = await server.submitTransaction(transaction);
+    } catch (e) {
+      console.log(e);
+    }
+    console.log("json", await submitResponse.json());
+  });
+
+  /*it("fee charged matched /info or /fee responses", async () => {
+    // Wait for _ to be defined
+    await new Promise(async (resolve) => {
+      let timePassed = 0;
+      while (!_ && timePassed < 5000) {
+        await new Promise(resolve => {setTimeout(resolve, 500)});
+        timePassed += 500;
+      }
+      resolve();
+    });
+    expect(_).not.toEqual(undefined);
+
+    let feeForTransaction;
+    if (infoJSON.fee.authentication_required) {
+      const paramString = `operation=withdraw&asset_code=${enabledCurrency}&amount=${transactionJSON.amount_in}`;
+      const feeResponse = await fetch(toml.TRANSFER_SERVER + `/fee?${paramString}`, {
+        headers: {"Authorization": `Bearer ${jwt}`}
+      });
+      const feeJSON = await feeResponse.json();
+      feeForTransaction = feeJSON.fee;
+    } else {
+      const feeFixed = infoJSON.withdraw[enabledCurrency].withdraw_fee_fixed;
+      const feePercent = infoJSON.withdraw[enabledCurrency].withdraw_fee_percent;
+      feeForTransaction = feeFixed + (feePercent * transactionJSON.amount_in);
+    }
+
+  })*/
+});

--- a/cases/transaction.test.js
+++ b/cases/transaction.test.js
@@ -99,22 +99,6 @@ describe("Transaction", () => {
     await checkTransactionResponse({ json: json, isDeposit: false });
   });
 
-  it.skip("json retreived by stellar_transaction_id returns correct object schema", async () => {
-    // Can't this test wouldn't succeed because stellar_transaction_id would be populated
-    // after the anchor submited the deposit to the stellar network. This test will have
-    // to wait until we have the code to walk through the interactive flow working.
-
-    // do interactive flow, then:
-
-    let json = await getTransactionBy({
-      iden: "stellar_transaction_id",
-      value: json.stellar_transaction_id,
-      toml: toml,
-      jwt: jwt,
-    });
-    await checkTransactionResponse({ json: json, isDeposit: true });
-  });
-
   it("return a proper available more_info_url transaction link", async () => {
     let { json } = await createTransaction({
       currency: enabledCurrency,

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -24,11 +24,12 @@ export const openObservableWindow = async (url) => {
   });
   await driver.switchTo().window(handles[1]);
   let observers = [];
-  setInterval(async () => {
+  let passPostMessage = setInterval(async () => {
     await driver.switchTo().window(handles[0]);
     const lastMessage = await driver.executeScript((_) => {
       const lastMessage = window.__LAST_POST_MESSAGE__;
       delete window.__LAST_POST_MESSAGE__;
+      console.log("GOT lastMessage");
       return lastMessage;
     });
     await driver.switchTo().window(handles[1]);
@@ -40,6 +41,12 @@ export const openObservableWindow = async (url) => {
   return {
     observePostMessage: (cb) => {
       observers.push(cb);
+    },
+    close: async () => {
+      clearInterval(passPostMessage);
+      await driver.switchTo().window(handles[1]);
+      driver.close();
+      await driver.switchTo().window(handles[0]);
     },
   };
 };

--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -29,7 +29,6 @@ export const openObservableWindow = async (url) => {
     const lastMessage = await driver.executeScript((_) => {
       const lastMessage = window.__LAST_POST_MESSAGE__;
       delete window.__LAST_POST_MESSAGE__;
-      console.log("GOT lastMessage");
       return lastMessage;
     });
     await driver.switchTo().window(handles[1]);

--- a/cases/util/interactive.js
+++ b/cases/util/interactive.js
@@ -57,9 +57,10 @@ export const doInteractiveFlow = async ({
   // Lets wait until the whole flow finishes by observering for
   // a postMessage awaiting user transfer start
   let complete = false;
-  window.observePostMessage((message) => {
+  window.observePostMessage(async (message) => {
     expect(message).toMatchSchema(getTransactionSchema(true));
     if (message.transaction.status == "pending_user_transfer_start") {
+      await window.close();
       complete = true;
     }
   });

--- a/cases/util/schema.js
+++ b/cases/util/schema.js
@@ -37,7 +37,6 @@ const transactionSchema = {
         },
         stellar_transaction_id: {
           type: ["string", "null"],
-          pattern: "G[A-Z0-9]{55}",
         },
         external_transaction_id: {
           type: ["string", "null"],
@@ -46,7 +45,7 @@ const transactionSchema = {
           type: ["string", "null"],
         },
         refunded: {
-          type: "boolean"
+          type: "boolean",
         },
       },
       required: [
@@ -61,8 +60,8 @@ const transactionSchema = {
         "completed_at",
         "stellar_transaction_id",
         "refunded",
-      ]
-    }
+      ],
+    },
   },
   required: ["transaction"],
 };
@@ -70,74 +69,84 @@ const transactionSchema = {
 export function getTransactionSchema(isDeposit) {
   const schema = JSON.parse(JSON.stringify(transactionSchema));
   const requiredDepositParams = ["from", "to"];
-  const requiredWithdrawParams = ["from", "to", "withdraw_memo", "withdraw_memo_type", "withdraw_anchor_account"];
+  const requiredWithdrawParams = [
+    "from",
+    "to",
+    "withdraw_memo",
+    "withdraw_memo_type",
+    "withdraw_anchor_account",
+  ];
 
   const depositProperties = {
     deposit_memo: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     deposit_memo_type: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     from: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     to: {
-      type: ["string", "null"]
-    }
+      type: ["string", "null"],
+    },
   };
 
   const withdrawProperties = {
     withdraw_anchor_account: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     withdraw_memo: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     withdraw_memo_type: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     from: {
-      type: ["string", "null"]
+      type: ["string", "null"],
     },
     to: {
-      type: ["string", "null"]
-    }
+      type: ["string", "null"],
+    },
   };
 
   if (isDeposit) {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(requiredDepositParams);
+    schema.properties.transaction.required = schema.properties.transaction.required.concat(
+      requiredDepositParams,
+    );
     Object.assign(schema.properties.transaction.properties, depositProperties);
   } else {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(requiredWithdrawParams);
+    schema.properties.transaction.required = schema.properties.transaction.required.concat(
+      requiredWithdrawParams,
+    );
     Object.assign(schema.properties.transaction.properties, withdrawProperties);
   }
-  
+
   return schema;
 }
 
 export const transactionsSchema = {
   type: "object",
   properties: {
-    transactions: { type: "array" }
+    transactions: { type: "array" },
   },
-  required: ["transactions"]
-}
+  required: ["transactions"],
+};
 
 export const errorSchema = {
   type: "object",
   properties: {
-    error: { type: "string" }
+    error: { type: "string" },
   },
-  required: ["error"]
+  required: ["error"],
 };
 
 export const feeSchema = {
   type: "object",
   properties: {
-    fee: { type: "number" }
+    fee: { type: "number" },
   },
-  required: ["fee"]
+  required: ["fee"],
 };
 
 const depositAndWithdrawSchema = {
@@ -151,7 +160,7 @@ const depositAndWithdrawSchema = {
         min_amount: { type: "number" },
         max_amount: { type: "number" },
       },
-      required: ["enabled"]
+      required: ["enabled"],
     },
   },
 };
@@ -165,14 +174,10 @@ export const infoSchema = {
       type: "object",
       properties: {
         enabled: { type: "boolean" },
-        authentication_required: { type: "boolean" }
+        authentication_required: { type: "boolean" },
       },
-      required: ["enabled"]
+      required: ["enabled"],
     },
   },
-  required: [
-    "deposit",
-    "withdraw",
-    "fee",
-  ]
+  required: ["deposit", "withdraw", "fee"],
 };

--- a/cases/withdraw.test.js
+++ b/cases/withdraw.test.js
@@ -1,17 +1,13 @@
-/**
- * @jest-environment ./cases/environment.js
- */
 import { fetch } from "./util/fetchShim";
 import getSep10Token from "./util/sep10";
 import StellarSDK from "stellar-sdk";
 import getTomlFile from "./util/getTomlFile";
-import { getTransactionBy } from "./util/transactions";
-import { createTransaction, doInteractiveFlow } from "./util/interactive";
+import { createTransaction } from "./util/interactive";
 const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
 const keyPair = StellarSDK.Keypair.random();
 
-jest.setTimeout(200000); // 20 sec timeout since we're actually stepping through web forms
+jest.setTimeout(20000); // 20 sec timeout since we're actually stepping through web forms
 
 describe("Withdraw", () => {
   let infoJSON;
@@ -95,24 +91,5 @@ describe("Withdraw", () => {
     expect(json.id).toEqual(expect.any(String));
     expect(() => new global.URL(interactiveURL)).not.toThrow();
     expect(status).toEqual(200);
-  });
-
-  describe("happy path", () => {
-    it("can load get through the interactive flow", async () => {
-      let transactionId = await doInteractiveFlow({
-        currency: enabledCurrency,
-        account: keyPair.publicKey(),
-        jwt: jwt,
-        toml: toml,
-        isDeposit: false,
-      });
-      await getTransactionBy({
-        iden: "id",
-        value: transactionId,
-        expectStatus: 200,
-        toml: toml,
-        jwt: jwt,
-      });
-    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "postinstall": "cd client && npm install && cd ..",
-    "test": "jest -i --verbose --runInBand",
+    "test": "jest -i --verbose --runInBand --json --outputFile=results.json",
     "server:dev": "PORT=3001 nodemon server/api.js",
     "start:dev": "concurrently \"cd client && REACT_APP_API_HOST=http://localhost:3001 npm start\" \"PORT=3001 npm run server:dev\"",
     "start": "node run.js",

--- a/server/jest-controller/list.js
+++ b/server/jest-controller/list.js
@@ -13,14 +13,15 @@ module.exports = async () => {
 
     jest.on("close", (code) => {
       const orderedTests = [
-        'toml',
-        'info',
-        'sep10',
-        'deposit',
-        'withdraw',
-        'transaction',
-        'transactions',
-        'fee.optional'
+        "toml",
+        "info",
+        "sep10",
+        "deposit",
+        "withdraw",
+        "transaction",
+        "transactions",
+        "fee.optional",
+        "interactive-flows.optional",
       ];
 
       const unorderedTests = output
@@ -28,10 +29,13 @@ module.exports = async () => {
         .split("\n")
         .map((line) => {
           const testName = path.basename(line).split(".test.js")[0];
-          if (orderedTests.includes(testName)) { return null; }
+          if (orderedTests.includes(testName)) {
+            return null;
+          }
           return testName;
-        }).filter(name => name !== null);
-      
+        })
+        .filter((name) => name !== null);
+
       const fullList = [...orderedTests, ...unorderedTests];
       resolve(fullList);
     });


### PR DESCRIPTION
resolves #54 

`interactive-flows.optional.test.js` tests that a both deposit and withdraw transaction can be completed on the stellar network via SEP-24. These tests are run in sequence because the enabled asset needs to be deposited in the stellar account before it can be withdrawn. 

There are other tests that require a completed transaction first, namely:
- That the fee charged matches the `/info` or `/fee` responses
- That a transaction can be retrieved using the `stellar_transaction_id` parameter
We can continue to add more.

A couple issues I ran into:
- `openObservableWindow` needed to be adjusted to close windows for finished interactive flows
- Polaris' `test-value` attributes had to be adjusted, since the fee charged on the deposit makes a withdrawal of the same amount invalid. nTokens and other Polaris anchors will have to upgrade to the upcoming 0.10.4 to pass these tests.

Open question: what should the timeout limits be for each test?