### PR TITLE
Add jest-expect-message and example

### DIFF
--- a/cases/toml.test.js
+++ b/cases/toml.test.js
@@ -26,7 +26,7 @@ describe("TOML File", () => {
     });
     expect(
       response.headers.get("access-control-allow-origin"),
-      "access-control-allow-origin response header should be set to *",
+      "access-control-allow-origin response header for toml file should be set to *",
     ).toBe("*");
   });
 

--- a/cases/toml.test.js
+++ b/cases/toml.test.js
@@ -24,7 +24,10 @@ describe("TOML File", () => {
         Origin: "https://test.com",
       },
     });
-    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(
+      response.headers.get("access-control-allow-origin"),
+      "access-control-allow-origin response header should be set to *",
+    ).toBe("*");
   });
 
   describe("fields", () => {

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
   "dependencies": {
     "@babel/core": "^7.8.6",
     "@babel/preset-env": "^7.8.6",
-    "bufferutil": "^4.0.1",
-    "canvas": "^2.5.0",
     "@stellar/prettier-config": "^1.0.1",
     "babel-jest": "^25.1.0",
+    "bufferutil": "^4.0.1",
+    "canvas": "^2.5.0",
     "chromedriver": "^80.0.1",
     "concurrently": "^5.0.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "jest": "^24.9.0",
+    "jest-expect-message": "^1.0.2",
     "jest-json-schema": "^2.1.0",
     "jest-junit": "^10.0.0",
     "jsonwebtoken": "^8.5.1",
@@ -51,7 +52,8 @@
       "jest-junit"
     ],
     "setupFilesAfterEnv": [
-      "./cases/util/setup.js"
+      "./cases/util/setup.js",
+      "jest-expect-message"
     ]
   },
   "husky": {


### PR DESCRIPTION
#17 

Installs the jest-expect-message plugin and adds an example of showing the cors expectation as an explained message.

Instead of 

```
expect(received).toBe(expected) // Object.is equality

Expected: "*"
Received: null
    at Object.<anonymous> (/Users/michaelfeldstein/Source/Stellar/transfer-server-validator/cases/toml.test.js:30:7)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

we get 

```
Error: Custom message:
  access-control-allow-origin header for toml file should be set to *

expect(received).toBe(expected) // Object.is equality

Expected: "*"
Received: null
    at Object.<anonymous> (/Users/michaelfeldstein/Source/Stellar/transfer-server-validator/cases/toml.test.js:30:7)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```