### PR TITLE
Strip ansi codes using regex

### DIFF
--- a/server/jest-controller/run-test.js
+++ b/server/jest-controller/run-test.js
@@ -13,7 +13,7 @@ module.exports = async (domain, test) => {
     );
     let jsonStr = "";
     jest.stdout.on("data", (data) => {
-      jsonStr += chunk.toString().replace(/\\u001b\[[0-9]{1,2}m/g, "");
+      jsonStr += data.toString().replace(/\\u001b\[[0-9]{1,2}m/g, "");
     });
 
     jest.stderr.on("data", (data) => {

--- a/server/jest-controller/run-test.js
+++ b/server/jest-controller/run-test.js
@@ -13,7 +13,7 @@ module.exports = async (domain, test) => {
     );
     let jsonStr = "";
     jest.stdout.on("data", (data) => {
-      jsonStr += data.toString();
+      jsonStr += chunk.toString().replace(/\\u001b\[[0-9]{1,2}m/g, "");
     });
 
     jest.stderr.on("data", (data) => {

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,4 +1,5 @@
 const runTest = require("./jest-controller/run-test");
+
 module.exports = async (req, res) => {
   // Set up server-sent events
   res.writeHead(200, {
@@ -8,17 +9,6 @@ module.exports = async (req, res) => {
     "Access-Control-Allow-Origin": "*",
   });
 
-  let i = 0;
-  const sendLoadingMessage = (_) => {
-    const message = ["Running Tests", "Still running tests", "Still going"][
-      i++ % 3
-    ];
-    res.write(`data: ${JSON.stringify({ loadingMessage: message })}\n\n`);
-  };
-  sendLoadingMessage();
-
-  const timer = setInterval(sendLoadingMessage, 5000);
   const results = await runTest(req.query.domain, req.query.test);
-  clearInterval(timer);
   res.write(`data: ${JSON.stringify({ results })}\n\n`);
 };

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,5 +1,4 @@
 const runTest = require("./jest-controller/run-test");
-
 module.exports = async (req, res) => {
   // Set up server-sent events
   res.writeHead(200, {


### PR DESCRIPTION
Fixes #48 

Strips out ansi codes using a regex.  the `strip-ansi` library works on actual unicode strings, but this is just a regular utf8 encoded string with escaped unicode characters in it so a raw regex was needed.

Also removes the now-defunct loading message stuff from run-tests