### PR TITLE
Fix heroku timeout problem

### DIFF
--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -8,6 +8,10 @@ module.exports = async (req, res) => {
     "Access-Control-Allow-Origin": "*",
   });
 
+  // It's important to write something to the stream immediately
+  // otherwise heroku will timeout with an H15 Idle Connection error
+  res.write("message: Starting Tests\n\n");
+
   const results = await runTest(req.query.domain, req.query.test);
   res.write(`data: ${JSON.stringify({ results })}\n\n`);
 };


### PR DESCRIPTION
In #77 i removed the unused loading messages being sent back from the api.  However, these were actually helpful because heroku will timeout a request if no data is sent back withing 30 seconds.  As long as you send back something immediately, you can keep the connection open indefinitely.  This was causing the sep10 tests to timeout on heroku but not locally since locally we don't have a timeout constraint.