### PR TITLE
Add actual code blocks to failing tests

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
         resetTests();
         setBusy(true);
         const domainForTests = getValidDomain();
-        window.history.replaceState(null, '', `?home_domain=${domain}`);
+        window.history.replaceState(null, "", `?home_domain=${domain}`);
         var nextTest: TestResultSet | undefined;
         while (
           (nextTest = testList.find(

--- a/client/src/Results.module.css
+++ b/client/src/Results.module.css
@@ -35,3 +35,31 @@
   color: blue;
   text-decoration: none;
 }
+
+.SourceLineSet {
+  background: white;
+  margin: 8px;
+}
+
+.SourceLineNumber {
+  width: 32px;
+  padding: 4px;
+  border-right: 1px solid black;
+  display: inline-block;
+}
+
+.SourceLineContent {
+  padding: 4px;
+}
+
+.SourceLine:nth-child(even) {
+  background: rgb(240, 240, 240);
+}
+
+.SourceLine:nth-child(odd) {
+  background: rgb(255, 255, 255);
+}
+
+.SourceLineActive {
+  background: rgba(241, 147, 147, 1) !important;
+}

--- a/client/src/TestList.tsx
+++ b/client/src/TestList.tsx
@@ -36,6 +36,26 @@ function TestListItem({ result }: { result: TestResult }) {
         {result.failureMessages?.map((m) => (
           <div>{m}</div>
         ))}
+        <div className={s.SourceLineSet}>
+          {result.releventSource?.map((sourceLine) => {
+            return (
+              <div
+                className={`${s.SourceLine} ${
+                  sourceLine.isErrorLine ? s.SourceLineActive : ""
+                }`}
+              >
+                <span className={s.SourceLineNumber}>
+                  <a href={sourceLine.directLink} target="_blank">
+                    {sourceLine.lineNumber}
+                  </a>
+                </span>
+                <span className={s.SourceLineContent}>
+                  {sourceLine.content}
+                </span>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/client/src/TestResults.ts
+++ b/client/src/TestResults.ts
@@ -6,10 +6,18 @@ export enum TestStatus {
   RUNNING = "Running",
 }
 
+export interface SourceLine {
+  content: string;
+  isErrorLine: boolean;
+  lineNumber: number;
+  directLink: string;
+}
+
 export interface TestResult {
   name: string;
   status: TestStatus;
   failureMessages?: string[];
+  releventSource?: SourceLine[];
 }
 export interface TestResultSet {
   name: string;

--- a/client/src/api/runTest.ts
+++ b/client/src/api/runTest.ts
@@ -57,6 +57,7 @@ export default async (domain: string, test: string): Promise<TestResult[]> => {
         name: [...testResult.ancestorTitles, testResult.title].join(" > "),
         status: enumFromStatusString(testResult.status),
         failureMessages: testResult.failureMessages,
+        releventSource: testResult.releventSource,
       };
     },
   );

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -1,4 +1,10 @@
+const e = require("express");
 const runTest = require("./jest-controller/run-test");
+
+/**
+ * @param {e.Request} req
+ * @param {e.Response} res
+ */
 module.exports = async (req, res) => {
   // Set up server-sent events
   res.writeHead(200, {
@@ -14,4 +20,5 @@ module.exports = async (req, res) => {
 
   const results = await runTest(req.query.domain, req.query.test);
   res.write(`data: ${JSON.stringify({ results })}\n\n`);
+  res.end();
 };


### PR DESCRIPTION
Fixes #76 

Adds code snippets around failing tests so people can see exactly whats happening and whats going wrong
Adds links to the direct line of code in github
Removes an unused file
Closes the websocket when the server is done.

<img width="824" alt="Screenshot 2020-03-20 at 12 18 44 PM" src="https://user-images.githubusercontent.com/161135/77198854-07ba0100-6aa5-11ea-862b-6a2819cb1a24.png">
