### PR TITLE
Fix slow tests timeout errors

### DIFF
--- a/cases/transactions.test.js
+++ b/cases/transactions.test.js
@@ -13,8 +13,7 @@ jest.setTimeout(60000);
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const domain = urlBuilder.toString();
-const secret = "SAUOSXXF7ZDO5PKHRFR445DRKZ66Q5HIM2HIPQGWBTUKJZQAOP3VGH3L";
-const keyPair = StellarSDK.Keypair.fromSecret(secret);
+const keyPair = StellarSDK.Keypair.random();
 
 describe("Transactions", () => {
   let toml;
@@ -335,7 +334,6 @@ describe("Transactions", () => {
       },
     );
     const pagingJson = await pagingTransaction.json();
-
     const transactionsResponse = await fetch(
       `${transferServer}/transactions?asset_code=${enabledCurrency}&kind=deposit&limit=1&paging_id=${pagingId}&no_older_than=${currentDate.toISOString()}`,
       {

--- a/server/jest-controller/run-test.js
+++ b/server/jest-controller/run-test.js
@@ -28,7 +28,9 @@ module.exports = async (domain, test) => {
         const name = testResult.name.split("/").reduce((prev, cur) => cur);
         testResult.assertionResults.forEach((assertionResult) => {
           assertionResult.failureMessages.forEach((failureMessage) => {
+            console.log("Failure message", failureMessage);
             const [_, file, lineStr] = firstLineRegex.exec(failureMessage);
+            console.log("File", file);
             const errorLine = parseInt(lineStr);
             const fileContents = fs.readFileSync(file).toString();
             const fileLines = fileContents.split("\n");

--- a/server/jest-controller/run-test.js
+++ b/server/jest-controller/run-test.js
@@ -32,20 +32,26 @@ module.exports = async (domain, test) => {
             const [_, file, lineStr] = firstLineRegex.exec(failureMessage);
             console.log("File", file);
             const errorLine = parseInt(lineStr);
-            const fileContents = fs.readFileSync(file).toString();
-            const fileLines = fileContents.split("\n");
-            const start = Math.max(0, errorLine - 4);
-            const end = Math.min(fileLines.length - 1, errorLine + 3);
-            const selectedLines = fileLines.slice(start, end).map((line, i) => {
-              const lineNumber = i + start + 1;
-              return {
-                content: line,
-                lineNumber: lineNumber,
-                isErrorLine: lineNumber === errorLine,
-                directLink: `https://github.com/stellar/transfer-server-validator/blob/master/cases/${name}#L${lineNumber}`,
-              };
-            });
-            assertionResult.releventSource = selectedLines;
+            try {
+              const fileContents = fs.readFileSync(file).toString();
+              const fileLines = fileContents.split("\n");
+              const start = Math.max(0, errorLine - 4);
+              const end = Math.min(fileLines.length - 1, errorLine + 3);
+              const selectedLines = fileLines
+                .slice(start, end)
+                .map((line, i) => {
+                  const lineNumber = i + start + 1;
+                  return {
+                    content: line,
+                    lineNumber: lineNumber,
+                    isErrorLine: lineNumber === errorLine,
+                    directLink: `https://github.com/stellar/transfer-server-validator/blob/master/cases/${name}#L${lineNumber}`,
+                  };
+                });
+              assertionResult.releventSource = selectedLines;
+            } catch (e) {
+              console.log("Couldn't read the file to create selected lines", e);
+            }
           });
         });
       });

--- a/server/run-tests.js
+++ b/server/run-tests.js
@@ -15,10 +15,16 @@ module.exports = async (req, res) => {
   });
 
   // It's important to write something to the stream immediately
-  // otherwise heroku will timeout with an H15 Idle Connection error
-  res.write("message: Starting Tests\n\n");
+  // and intermittently otherwise heroku will timeout with
+  // an H15 Idle Connection error
+  const sendPing = () => {
+    res.write("message: Running Tests\n\n");
+  };
+  sendPing();
+  const timer = setInterval(sendPing, 15000);
 
   const results = await runTest(req.query.domain, req.query.test);
+  clearTimeout(timer);
   res.write(`data: ${JSON.stringify({ results })}\n\n`);
   res.end();
 };


### PR DESCRIPTION
Some tests were taking a really long time and introducing "Something went wrong" timeout errors.  The cause was twofold

1) the tests should not be slow.  This was caused by reusing the same secret key in the /transactions tests, so you'd end up with thousands of transactions to test

2) If they are slow we shouldn't have timeout errors (at least herokus unhandled timeout errors).  Instead we send the 'loading message' thing so at least a byte goes over the wire every 15 seconds and avoids herokus 55s timeout.

We also wrap the stack trace annotation in a try catch, there are some errors that have a bad stacktrace and give us a file that's not there.  I'm not sure exactly what causes it but this will prevent the whole thing from fubaring.