### PR TITLE
Fail sep10 util early

### DIFF
--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -89,6 +89,10 @@ describe("SEP10", () => {
     const json = await fetch(
       toml.WEB_AUTH_ENDPOINT + "?account=" + unfundedKeypair.publicKey(),
     ).then((r) => r.json());
+    expect(
+      json.error,
+      "Received an error trying to fetch a SEP10 challenge",
+    ).toBeFalsy();
     const tx = new StellarSDK.Transaction(
       json.transaction,
       toml.NETWORK_PASSPHRASE || StellarSDK.Networks.TESTNET,

--- a/cases/util/sep10.js
+++ b/cases/util/sep10.js
@@ -11,7 +11,10 @@ export default async function getSep10Token(domain, keyPair, signers) {
   const json = await response.json();
   const network_passphrase =
     toml.NETWORK_PASSPHRASE || StellarSDK.Networks.TESTNET;
-  const tx = new StellarSDK.Transaction(json.transaction, network_passphrase);
+  let tx;
+  expect(() => {
+    tx = new StellarSDK.Transaction(json.transaction, network_passphrase);
+  }, `This test needs a valid SEP10 token but can't build the returned challenge: "${json.transaction}" and error: "${json.error}"`).not.toThrow();
   signers.forEach((keyPair) => {
     tx.sign(keyPair);
   });


### PR DESCRIPTION
Some tests were failing because of an odd error in the SEP10 util class.  Instead of showing a weird xdr error, we now show a clear message when there's not a valid challenge tx in the sep10 flow