### PR TITLE
Add SEP10 test for signer without an account

### DIFF
--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -223,6 +223,12 @@ describe("SEP10", () => {
       await friendbot.destroyAllFriends();
     });
 
+    it("succeeds for a signer without an account", async () => {
+      const kp = StellarSDK.Keypair.random();
+      const token = getSep10Token(url, kp, [kp]);
+      expect(token).toBeTruthy();
+    });
+
     /**
      * Removing the masterWeight for an account means that it can
      * no longer sign for itself.  This should mean that it can't

--- a/cases/sep10.test.js
+++ b/cases/sep10.test.js
@@ -26,7 +26,7 @@ const getAccount = (function() {
 })();
 
 beforeAll(async () => {
-  for (let i = 0; i < 9; i++) {
+  for (let i = 0; i < 10; i++) {
     accountPool.push({ kp: StellarSDK.Keypair.random(), data: null });
   }
   await Promise.all(
@@ -225,8 +225,15 @@ describe("SEP10", () => {
 
     it("succeeds for a signer without an account", async () => {
       const kp = StellarSDK.Keypair.random();
-      const token = getSep10Token(url, kp, [kp]);
+      const token = await getSep10Token(url, kp, [kp]);
       expect(token).toBeTruthy();
+    });
+
+    it("fails when a signer with an account signs alongside signer without an account", async () => {
+      const account = getAccount();
+      const kp = StellarSDK.Keypair.random();
+      const token = await getSep10Token(url, kp, [kp, account.kp]);
+      expect(token).toBeFalsy();
     });
 
     /**
@@ -235,7 +242,7 @@ describe("SEP10", () => {
      * get a token with its own signature.
      */
     it("fails for an account that can't sign for itself", async () => {
-      const account = getAccount({ with_data: true });
+      const account = getAccount();
       const transaction = new StellarSDK.TransactionBuilder(account.data, {
         fee: StellarSDK.BASE_FEE,
         networkPassphrase: StellarSDK.Networks.TESTNET,
@@ -257,7 +264,7 @@ describe("SEP10", () => {
     });
 
     it("succeeds for a signer of an account", async () => {
-      const userAccount = getAccount({ with_data: true });
+      const userAccount = getAccount();
       const signerAccount = getAccount();
       const transaction = new StellarSDK.TransactionBuilder(userAccount.data, {
         fee: StellarSDK.BASE_FEE,
@@ -291,7 +298,7 @@ describe("SEP10", () => {
      * count its weight twice.
      */
     it("fails when trying to reuse the same signer to gain weight", async () => {
-      const userAccount = getAccount({ with_data: true });
+      const userAccount = getAccount();
       const signerAccount = getAccount();
       const transaction = new StellarSDK.TransactionBuilder(userAccount.data, {
         fee: StellarSDK.BASE_FEE,
@@ -320,7 +327,7 @@ describe("SEP10", () => {
     });
 
     it("succeeds with multiple signers", async () => {
-      const userAccount = getAccount({ with_data: true });
+      const userAccount = getAccount();
       const signerAccount1 = getAccount();
       const signerAccount2 = getAccount();
       const transaction = new StellarSDK.TransactionBuilder(userAccount.data, {


### PR DESCRIPTION
resolves #71 

Our reference server fails the 2nd test because it doesn't check that there is only 1 signer on the challenge if the account doesn't exist. I have a issue filed for that and am adding the check now.