### PR TITLE
More robust test for paging id

### DIFF
--- a/cases/transactions.test.js
+++ b/cases/transactions.test.js
@@ -303,7 +303,8 @@ describe("Transactions", () => {
       const pagingStartedTime = new Date(
         pagingJson.transaction.started_at,
       ).getTime();
-      expect(transactionStartedTime).toBeLessThan(pagingStartedTime);
+      expect(transactionStartedTime).toBeLessThanOrEqual(pagingStartedTime);
+      expect(transaction.id).not.toBe(pagingJson.transaction.id);
     });
   });
 
@@ -346,7 +347,10 @@ describe("Transactions", () => {
     const transactionsJson = await transactionsResponse.json();
     expect(transactionsResponse.status).toEqual(200);
     expect(transactionsJson.error).not.toBeDefined();
-    expect(transactionsJson.transactions.length).toBe(1);
+    expect(
+      transactionsJson.transactions.length,
+      "Limit of this request was set to 1",
+    ).toBe(1);
 
     transactionsJson.transactions.forEach((transaction) => {
       const transactionStartedTime = new Date(transaction.started_at).getTime();


### PR DESCRIPTION
If the two transactions of the test are created fast enough (<1s) then both transactions will have the same timestamp.  Its not valid to say the timestamp of the tx previous to the paging id must be less than the timestamp of the paging tx, since they can be equal.  It is valid to say it cannot be greater than, and it is valid to say the id's cannot be the same.