### PR TITLE
Fix StaleElementReferenceBug

### DIFF
--- a/cases/util/browser-util.js
+++ b/cases/util/browser-util.js
@@ -43,9 +43,14 @@ export const openObservableWindow = async (url) => {
     },
     close: async () => {
       clearInterval(passPostMessage);
-      await driver.switchTo().window(handles[1]);
-      driver.close();
-      await driver.switchTo().window(handles[0]);
+      // Close the window containing the interactive flow
+      // if it is still open.
+      let handles = await driver.getAllWindowHandles();
+      if (handles.length === 2) {
+        await driver.switchTo().window(handles[1]);
+        driver.close();
+        await driver.switchTo().window(handles[0]);
+      }
     },
   };
 };


### PR DESCRIPTION
resolves #68

I debugged and found the error was raised by referencing the 2nd window from the `close` method returned from `openObservableWindow`.

After adding a new call
```
let handles = await driver.getAllWindowHandles();
```
And checking that there is 2 windows returned, I didn't get the error again after many test runs. Before, the stale reference error would happen about 1 out of 3 times.

While this may fix the issue I'm not sure why the 2nd window would no longer exist, since there's nothing that would close it. Maybe it does still exist but the element reference is stale, so another call to get all the windows returned fresh references.