### PR TITLE
Fixed StaleElementRefereceError

### DIFF
--- a/cases/util/interactive.js
+++ b/cases/util/interactive.js
@@ -67,9 +67,8 @@ export const doInteractiveFlow = async ({
   });
   const completePage = async () => {
     try {
-      let el;
       const elements = await driver.findElements(By.css("[test-value]"));
-      for (el of elements) {
+      for (let el of elements) {
         const val = await el.getAttribute("test-value");
         await el.clear();
         await el.sendKeys(val);

--- a/cases/util/interactive.js
+++ b/cases/util/interactive.js
@@ -67,11 +67,13 @@ export const doInteractiveFlow = async ({
   });
   const completePage = async () => {
     try {
+      let el;
       const elements = await driver.findElements(By.css("[test-value]"));
-      elements.forEach((el) => {
-        const val = el.getAttribute("test-value");
-        el.sendKeys(val);
-      });
+      for (el of elements) {
+        const val = await el.getAttribute("test-value");
+        await el.clear();
+        await el.sendKeys(val);
+      }
       const submitButton = await driver.findElement(
         By.css("[test-action='submit']"),
       );
@@ -81,7 +83,8 @@ export const doInteractiveFlow = async ({
 
       await submitButton.click();
     } catch (e) {
-      // Not an automatable page, could be the receipt page postMessaging
+      // An error was raised due to no such element or stale element
+      // reference error. Try again on the next loop.
     }
   };
   return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
resolves #68

Turns out, we weren't using `await` on the `sendKeys` call, so it wouldn't get caught by the try/catch block. `forEach` doesn't work with async/await so I changed that as well. 

I also `clear()` the keys before trying to submit them. Sometimes we would fail to submit the first time, add the text to the keys again, and get an invalid email error.