### PR TITLE
Base-64 Memo Test and Handling

### DIFF
--- a/cases-SEP24/interactive-flows.optional.test.js
+++ b/cases-SEP24/interactive-flows.optional.test.js
@@ -194,6 +194,9 @@ describe("Withdraw Flow", () => {
   it("marks transaction as complete after submission", async () => {
     // Wait for transactionJSON to be defined
     await waitUntilTruthy({ val: transactionJSON }, 25000, 2000);
+    let memo = Buffer.from(transactionJSON.withdraw_memo, "base64").toString(
+      "hex",
+    );
 
     // Submit transaction
     const distributionAccount = transactionJSON.withdraw_anchor_account;
@@ -208,7 +211,7 @@ describe("Withdraw Flow", () => {
           amount: transactionJSON.amount_in,
         }),
       )
-      .addMemo(StellarSDK.Memo.hash(transactionJSON.withdraw_memo))
+      .addMemo(StellarSDK.Memo.hash(memo))
       .setTimeout(30)
       .build();
     transaction.sign(keyPair);

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -158,4 +158,23 @@ describe("Transaction", () => {
     });
     expect(json).toMatchSchema(errorSchema);
   });
+
+  it("memos are base64-encoded", async () => {
+    let { json } = await createTransaction({
+      currency: enabledCurrency,
+      account: keyPair.publicKey(),
+      toml: toml,
+      jwt: jwt,
+      isDeposit: false,
+    });
+    json = await getTransactionBy({
+      value: json.id,
+      toml: toml,
+      jwt: jwt,
+    });
+    function decode() {
+      Buffer.from(json.transaction.withdraw_memo, "base64");
+    }
+    expect(decode).not.toThrow();
+  });
 });


### PR DESCRIPTION
One issue is that this validiator assumes anchors are generating the withdraw memo because we aren't sending them in requests. The SEP makes it clear that memo's can be sent in requests, but Polaris doesn't support that, and we don't test for it here.

Should we add something to the SEP to clarify when anchors should generate their own memos and whether or not supporting the `memo` request parameter is optional?