### PR TITLE
Ensure withdraw_memo is used correctly by anchor

### DIFF
--- a/cases-SEP24/interactive-flows.optional.test.js
+++ b/cases-SEP24/interactive-flows.optional.test.js
@@ -273,4 +273,16 @@ describe("Withdraw Flow", () => {
     let json = await response.json();
     expect(json).toMatchSchema(getTransactionSchema(false));
   });
+
+  it("withdraw_memo is base64-encoded", async () => {
+    // Wait for withdrawJSON to be defined
+    waitUntilTruthy({ val: withdrawJSON }, 30000, 2000);
+
+    expect(withdrawJSON.withdraw_fee_percent).not.toEqual(null);
+    expect(withdrawJSON.withdraw_fee_percent).not.toEqual("");
+    function decode() {
+      Buffer.from(withdrawJSON.withdraw_memo, "base64");
+    }
+    expect(decode).not.toThrow();
+  });
 });

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -158,20 +158,4 @@ describe("Transaction", () => {
     });
     expect(json).toMatchSchema(errorSchema);
   });
-
-  it("withdraw_memo is null after transaction creation", async () => {
-    let { json } = await createTransaction({
-      currency: enabledCurrency,
-      account: keyPair.publicKey(),
-      toml: toml,
-      jwt: jwt,
-      isDeposit: false,
-    });
-    json = await getTransactionBy({
-      value: json.id,
-      toml: toml,
-      jwt: jwt,
-    });
-    expect(json.transaction.withdraw_memo).toEqual(null);
-  });
 });

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -159,7 +159,7 @@ describe("Transaction", () => {
     expect(json).toMatchSchema(errorSchema);
   });
 
-  it("memos are base64-encoded", async () => {
+  it("withdraw_memo is null after transaction creation", async () => {
     let { json } = await createTransaction({
       currency: enabledCurrency,
       account: keyPair.publicKey(),
@@ -172,9 +172,6 @@ describe("Transaction", () => {
       toml: toml,
       jwt: jwt,
     });
-    function decode() {
-      Buffer.from(json.transaction.withdraw_memo, "base64");
-    }
-    expect(decode).not.toThrow();
+    expect(json.transaction.withdraw_memo).toEqual(null);
   });
 });


### PR DESCRIPTION
resolve stellar/transfer-server-validator#119

The `withdraw_memo` field in a `/transaction` response should be null until the interactive flow completes and base64-encoded once its created.

Use of deposit memos is optional since they are client specified, whereas withdraw memos should be generated by the anchor so they can identify it on the network later.