### PR TITLE
Add recoverXLM.js script, use HD keypairs

### DIFF
--- a/cases-SEP24/sep10.test.js
+++ b/cases-SEP24/sep10.test.js
@@ -1,4 +1,3 @@
-import { fetch } from "../util/fetchShim";
 import JWT from "jsonwebtoken";
 import StellarSDK from "stellar-sdk";
 import friendbot from "../util/friendbot";
@@ -47,12 +46,10 @@ const getAccount = (function() {
 
 beforeAll(async () => {
   if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-    let kps = [];
-    for (let i = 0; i < 10; i++) kps.push(StellarSDK.Keypair.random());
     masterAccount.data = await server.loadAccount(masterAccount.kp.publicKey());
     accountPool = await createAccountsFrom(
       masterAccount,
-      kps,
+      10,
       server,
       networkPassphrase,
     );

--- a/cases-SEP6/sep10.test.js
+++ b/cases-SEP6/sep10.test.js
@@ -1,4 +1,3 @@
-import { fetch } from "../util/fetchShim";
 import JWT from "jsonwebtoken";
 import StellarSDK from "stellar-sdk";
 import friendbot from "../util/friendbot";
@@ -47,12 +46,10 @@ const getAccount = (function() {
 
 beforeAll(async () => {
   if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-    let kps = [];
-    for (let i = 0; i < 10; i++) kps.push(StellarSDK.Keypair.random());
     masterAccount.data = await server.loadAccount(masterAccount.kp.publicKey());
     accountPool = await createAccountsFrom(
       masterAccount,
-      kps,
+      10,
       server,
       networkPassphrase,
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5226,6 +5226,18 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bip39": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
+      "integrity": "sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==",
+      "requires": {
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
+      }
+    },
     "blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
@@ -5690,6 +5702,15 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -5991,6 +6012,31 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "requires": {
         "buffer": "^5.1.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -7219,6 +7265,33 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -11618,6 +11691,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -12306,6 +12389,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "pegjs": {
       "version": "0.10.0",
@@ -13070,6 +13165,15 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -13800,6 +13904,39 @@
         }
       }
     },
+    "stellar-hd-wallet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stellar-hd-wallet/-/stellar-hd-wallet-0.0.10.tgz",
+      "integrity": "sha512-rkg3Q394S6A4h1EYWwACz1v8hkU8zkW574THZ0yY96A8aUqifdBPtVYMInyYbq+le5S+K/Q05x/TZzTAPTIivQ==",
+      "requires": {
+        "bip39": "^2.5.0",
+        "create-hmac": "^1.1.7",
+        "lodash": "^4.17.11",
+        "stellar-base": "^0.13.1"
+      },
+      "dependencies": {
+        "stellar-base": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-0.13.2.tgz",
+          "integrity": "sha512-y0GO3L+HWPx4auyR8QiAC2uRqoa23MzJ9BnVzm1Li/0VsC5oWH82K7Nj040o++Q61KLIVhiZyKZNwCLHj1+0zw==",
+          "requires": {
+            "base32.js": "^0.1.0",
+            "bignumber.js": "^4.0.0",
+            "crc": "^3.5.0",
+            "js-xdr": "^1.1.1",
+            "lodash": "^4.17.11",
+            "sha.js": "^2.3.6",
+            "sodium-native": "^2.3.0",
+            "tweetnacl": "^1.0.0"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
     "stellar-sdk": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-3.3.0.tgz",
@@ -14480,6 +14617,11 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
+    },
+    "unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "server:dev": "PORT=3001 nodemon server/api.js",
     "start:dev": "concurrently \"cd client && REACT_APP_API_HOST=http://localhost:3001 npm start\" \"PORT=3001 npm run server:dev\"",
     "start": "node run.js",
-    "heroku-postbuild": "cd client && yarn && yarn run build"
+    "heroku-postbuild": "cd client && yarn && yarn run build",
+    "recover-xlm": "node recoverXLM.js"
   },
   "engines": {
     "node": ">=10.16.3"
@@ -38,6 +39,7 @@
     "node-fetch": "^2.6.0",
     "nodemon": "^2.0.4",
     "selenium-webdriver": "^4.0.0-alpha.7",
+    "stellar-hd-wallet": "0.0.10",
     "stellar-sdk": "^3.3.0",
     "stmux": "^1.8.0",
     "toml": "^3.0.0",

--- a/util/recoverXLM.js
+++ b/util/recoverXLM.js
@@ -1,0 +1,65 @@
+import StellarSDK from "stellar-sdk";
+import StellarHDWallet from "stellar-hd-wallet";
+import { resubmitOnRecoverableFailure } from "./transactions";
+
+const server = StellarSDK.Server("https://horizon.stellar.org");
+const masterKeypair = StellarSDK.Keypair.from_secret(
+  process.env.MAINNET_MASTER_SECRET_KEY,
+);
+// Generate the same keypairs used in sep10.test.js
+const wallet = StellarHDWallet.fromSeed(
+  new Buffer.from(masterKeypair.secret()).toString("hex"),
+);
+const keypairs = [...Array(10).keys()].map((x) => wallet.getKeypair(x));
+
+async function mergeAccountToMaster(keypair) {
+  const tb = new StellarSDK.TransactionBuilder(
+    await server.loadAccount(masterKeypair),
+    {
+      fee: StellarSDK.BASE_FEE * 5,
+      networkPassphrase: StellarSDK.Networks.PUBLIC,
+    },
+  );
+  tb.addOperation(
+    StellarSDK.Operation.accountMerge({
+      destination: masterKeypair.publicKey(),
+      source: keypair.publicKey(),
+    }),
+  );
+  const tx = tb.setTimeout(60).build();
+  tx.sign(keypair, masterKeypair);
+  let response;
+  try {
+    response = server.submitTransaction(tx);
+  } catch (e) {
+    response = resubmitOnRecoverableFailure(
+      e.response.data,
+      masterKeypair,
+      [keypair],
+      tb,
+      server,
+    );
+  }
+  if (!response.successful) {
+    throw {
+      error: `Unabled to merge account ${keypair.secret()}`,
+      data: response,
+    };
+  }
+}
+
+const results = await Promise.all(
+  keypairs.map(async (kp) => {
+    try {
+      await mergeAccountToMaster(kp);
+    } catch (e) {
+      console.log(e);
+      return false;
+    }
+    return true;
+  }),
+);
+console.log(
+  "Number of accounts merged successfully: " +
+    results.filter((val) => val).length,
+);

--- a/util/recoverXLM.js
+++ b/util/recoverXLM.js
@@ -1,6 +1,6 @@
 import StellarSDK from "stellar-sdk";
 import StellarHDWallet from "stellar-hd-wallet";
-import { resubmitOnRecoverableFailure } from "./transactions";
+import { mergeAccountToMaster } from "./sep10";
 
 const server = StellarSDK.Server("https://horizon.stellar.org");
 const masterKeypair = StellarSDK.Keypair.from_secret(
@@ -12,46 +12,15 @@ const wallet = StellarHDWallet.fromSeed(
 );
 const keypairs = [...Array(10).keys()].map((x) => wallet.getKeypair(x));
 
-async function mergeAccountToMaster(keypair) {
-  const tb = new StellarSDK.TransactionBuilder(
-    await server.loadAccount(masterKeypair),
-    {
-      fee: StellarSDK.BASE_FEE * 5,
-      networkPassphrase: StellarSDK.Networks.PUBLIC,
-    },
-  );
-  tb.addOperation(
-    StellarSDK.Operation.accountMerge({
-      destination: masterKeypair.publicKey(),
-      source: keypair.publicKey(),
-    }),
-  );
-  const tx = tb.setTimeout(60).build();
-  tx.sign(keypair, masterKeypair);
-  let response;
-  try {
-    response = server.submitTransaction(tx);
-  } catch (e) {
-    response = resubmitOnRecoverableFailure(
-      e.response.data,
-      masterKeypair,
-      [keypair],
-      tb,
-      server,
-    );
-  }
-  if (!response.successful) {
-    throw {
-      error: `Unabled to merge account ${keypair.secret()}`,
-      data: response,
-    };
-  }
-}
-
 const results = await Promise.all(
   keypairs.map(async (kp) => {
     try {
-      await mergeAccountToMaster(kp);
+      await mergeAccountToMaster(
+        masterKeypair,
+        kp,
+        server,
+        StellarSDK.Networks.PUBLIC,
+      );
     } catch (e) {
       console.log(e);
       return false;
@@ -59,6 +28,7 @@ const results = await Promise.all(
     return true;
   }),
 );
+
 console.log(
   "Number of accounts merged successfully: " +
     results.filter((val) => val).length,

--- a/util/sep10.js
+++ b/util/sep10.js
@@ -143,9 +143,9 @@ export async function mergeAccountToMaster(
   tx.sign(keypair);
   let response;
   try {
-    response = server.submitTransaction(tx);
+    response = await server.submitTransaction(tx);
   } catch (e) {
-    response = resubmitOnRecoverableFailure(
+    response = await resubmitOnRecoverableFailure(
       e.response.data,
       keypair,
       [],

--- a/util/sep10.js
+++ b/util/sep10.js
@@ -1,4 +1,5 @@
 import StellarSDK from "stellar-sdk";
+import StellarHDWallet from "stellar-hd-wallet";
 import { loggableFetch } from "./loggableFetcher";
 import getTomlFile from "./getTomlFile";
 import { resubmitOnRecoverableFailure } from "./transactions";
@@ -30,10 +31,16 @@ export async function getSep10Token(domain, keyPair, signers) {
 
 export async function createAccountsFrom(
   masterAccount,
-  keypairs,
+  numAccounts,
   server,
   networkPassphrase,
 ) {
+  const wallet = StellarHDWallet.fromSeed(
+    new Buffer.from(masterAccount.kp.secret()).toString("hex"),
+  );
+  const keypairs = [...Array(numAccounts).keys()].map((x) =>
+    wallet.getKeypair(x),
+  );
   const builder = new StellarSDK.TransactionBuilder(masterAccount.data, {
     fee: StellarSDK.BASE_FEE * keypairs.length * 5, // 5X base fee
     networkPassphrase: networkPassphrase,


### PR DESCRIPTION
resolves stellar/transfer-server-validator#137

**How XLM is lost (sometimes):**
Currently, temporary accounts are created and funded with XLM stored in a master account before beginning SEP10 tests. These tests modify the signers on these accounts, _but should always restore the original signer configuration of an account after the test completes_. However, this does not always happen due to bugs in the code or horizon errors.

When the accounts' signer configurations are not restored to the original state (1 master key signer per account), merging the randomly generated accounts fails since the master keys of the temp accounts can't authorize the transaction.

What makes things worse is that merging these accounts is done in a single transaction, meaning if 1 account was not restored properly, no accounts are merged.

**Solution:**
- Changes the way accounts are merged by making an `AccountMerge` transaction for every generated account. This change should minimize the amount of XLM lost.
- Uses HD keypairs (via [SEP-0005](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0005.md)) to create the same temporary keypairs derived from the master keypair each time tests are run.
- Adds a CLI tool for recovering the XLM from temporary accounts when they are not correctly merged after testing. This is just for convenience. 

**Downside**
Since we use the same temporary accounts each time, simultaneous test runs would cause one to fail, since the 2nd process would fail to create accounts that already exist. Even if we change the code to use the existing accounts, the signers of these accounts have been modified by the 1st process, so the 2nd process would still fail.

The solution would be to create new accounts for each process, but that defeats the purpose of using HD accounts since we wouldn't know which derived accounts would need to be recovered if they aren't successfully merged.

**Discussion**
Do we want to use derived accounts or continue using randomly generated ones? 

With the derived accounts we can merge them back without looking in the logs for the randomly generated secret keys, but we lose the ability to run multiple mainnet testing processes concurrently.

With the change to how accounts are merged, less XLM will be lost when accounts are not successfully merged, but it is still possible.