### PR TITLE
Use auth for info endpoint tests

### DIFF
--- a/cases-SEP31/send.test.js
+++ b/cases-SEP31/send.test.js
@@ -22,7 +22,8 @@ describe("POST /send", () => {
       testCurrency,
       server,
     ));
-    ({ token: jwt } = await getSep10Token(url, keyPair));
+    const tokenResponse = await getSep10Token(url, keyPair);
+    jwt = tokenResponse.token;
   });
 
   it("fails with no authentication", async () => {

--- a/cases-SEP31/send.test.js
+++ b/cases-SEP31/send.test.js
@@ -1,7 +1,7 @@
 import { fetch } from "../util/fetchShim";
 import getTomlFile from "./util/getTomlFile";
 import { getActiveCurrency } from "./util/currency";
-import getSep10Token from "../util/sep10";
+import { getSep10Token } from "../util/sep10";
 import { convertSEP31Fields } from "./util/sep9-fields";
 import { keyPair } from "./util/registeredKeypair";
 
@@ -21,6 +21,7 @@ describe("POST /send", () => {
     ({ enabledCurrency, infoJSON } = await getActiveCurrency(
       testCurrency,
       server,
+      url,
     ));
     const tokenResponse = await getSep10Token(url, keyPair);
     jwt = tokenResponse.token;
@@ -47,7 +48,7 @@ describe("POST /send", () => {
   });
 
   it("succeeds", async () => {
-    const values = convertSEP31Fields(infoJSON.send[enabledCurrency].fields);
+    const values = convertSEP31Fields(infoJSON.receive[enabledCurrency].fields);
     const headers = { Authorization: `Bearer ${jwt}` };
     const resp = await fetch(toml.DIRECT_PAYMENT_SERVER + "/send", {
       method: "POST",

--- a/cases-SEP31/util/currency.js
+++ b/cases-SEP31/util/currency.js
@@ -1,15 +1,19 @@
 import { fetch } from "../../util/fetchShim";
-
-export const getActiveCurrency = async (testCurrency, server) => {
+import { getSep10Token } from "../../util/sep10";
+import { keyPair } from "./registeredKeypair";
+export const getActiveCurrency = async (testCurrency, server, domain) => {
+  console.log("SERVER", domain);
+  const { token: jwt } = await getSep10Token(domain, keyPair);
   const infoResponse = await fetch(server + "/info", {
     headers: {
       Origin: "https://www.website.com",
+      Authorization: `Bearer ${jwt}`,
     },
   });
   const infoJSON = await infoResponse.json();
 
-  const currenciesDictionary = infoJSON.send;
-  const currencies = Object.keys(infoJSON.send);
+  const currenciesDictionary = infoJSON.receive;
+  const currencies = Object.keys(infoJSON.receive);
 
   const enabledCurrency = testCurrency
     ? testCurrency

--- a/cases-SEP31/util/schema.js
+++ b/cases-SEP31/util/schema.js
@@ -188,7 +188,7 @@ const fieldSchema = {
 export const infoSchema = {
   type: "object",
   properties: {
-    send: {
+    receive: {
       type: "object",
       patternProperties: {
         ".*": {
@@ -213,5 +213,5 @@ export const infoSchema = {
       },
     },
   },
-  required: ["send"],
+  required: ["receive"],
 };

--- a/util/getTomlFile.js
+++ b/util/getTomlFile.js
@@ -6,7 +6,10 @@ export default async function(domain) {
   const text = await response.text();
   const toml = TOML.parse(text);
   // Remove trailing slashes for consistency in building URLs
-  if (toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] === "/") {
+  if (
+    toml.TRANSFER_SERVER &&
+    toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] === "/"
+  ) {
     toml.TRANSFER_SERVER = toml.TRANSFER_SERVER.slice(0, -1);
   }
   if (toml.TRANSFER_SERVER_SEP0024) {


### PR DESCRIPTION
SEP31 [requires auth for all endpoints](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#authentication).  We probably shouldn't require it for /info, but in the meantime we should make sure the validator matches the spec, so this adds a jwt to all the /info endpoint tests.

It also fixes invalid schema for /info endpoint.