### PR TITLE
SEP31 fix transaction schema

### DIFF
--- a/cases-SEP31/util/schema.js
+++ b/cases-SEP31/util/schema.js
@@ -59,7 +59,7 @@ export const transactionSchema = {
       required: [
         "id",
         "status",
-        "stellar_transaction_id",
+        "stellar_account_id",
         "stellar_memo",
         "stellar_memo_type",
       ],


### PR DESCRIPTION
We incorrectly had stellar_transaction_id as a required property, but it is not required (its not available until payment is sent), but stellar_account_id is required, it can be populated as soon as there is a valid sep31-transaction