### PR TITLE
Use 403 response code instead of 401

### DIFF
--- a/cases-SEP31/send.test.js
+++ b/cases-SEP31/send.test.js
@@ -42,7 +42,7 @@ describe("POST /send", () => {
         }),
       },
     );
-    expect(status, logs).toBe(401);
+    expect(status, logs).toBe(403);
   });
 
   it("fails with no amount", async () => {

--- a/cases-SEP31/transaction.test.js
+++ b/cases-SEP31/transaction.test.js
@@ -59,11 +59,11 @@ describe("GET /transaction", () => {
     expect(status, logs).toBe(404);
   });
 
-  it("should 401 for an unauthenticated request", async () => {
+  it("should 403 for an unauthenticated request", async () => {
     const resp = await fetch(
       `${toml.DIRECT_PAYMENT_SERVER}/transaction?id=${transaction.id}`,
     );
-    expect(resp.status).toBe(401);
+    expect(resp.status).toBe(403);
   });
 
   it("should return a valid schema for a proper request", async () => {


### PR DESCRIPTION
We updated SEP31 to use 403 response for missing SEP10 tokens so we need to update the tests to reflect that
https://github.com/stellar/stellar-protocol/pull/661/files