### PR TITLE
Update schema of transaction object, show detailed logs for info test

### DIFF
--- a/cases-SEP31/info.test.js
+++ b/cases-SEP31/info.test.js
@@ -1,4 +1,4 @@
-import { fetch } from "../util/fetchShim";
+import { loggableFetch } from "../util/loggableFetcher";
 import getTomlFile from "./util/getTomlFile";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
@@ -35,25 +35,23 @@ describe("Info", () => {
   });
 
   describe("happy path", () => {
-    let json;
+    let json, logs;
 
     beforeAll(async () => {
-      const response = await fetch(DIRECT_PAYMENT_SERVER + "/info", {
+      const response = await loggableFetch(DIRECT_PAYMENT_SERVER + "/info", {
         headers: {
           Origin: "https://www.website.com",
           Authorization: `Bearer ${jwt}`,
         },
       });
+      json = response.json;
+      logs = response.logs;
       expect(response.status).toEqual(200);
-      expect(response.headers.get("content-type")).toEqual(
-        expect.stringContaining("application/json"),
-      );
-      json = await response.json();
       expect(json).toBeTruthy();
     });
 
     it("has a proper schema", () => {
-      expect(json, json).toMatchSchema(infoSchema);
+      expect(json, logs).toMatchSchema(infoSchema);
     });
   });
 });

--- a/cases-SEP31/util/schema.js
+++ b/cases-SEP31/util/schema.js
@@ -105,14 +105,14 @@ export const infoSchema = {
             fee_percent: { type: "number" },
             min_amount: { type: "number" },
             max_amount: { type: "number" },
+            sender_sep12_type: { type: "string" },
+            receiver_sep12_type: { type: "string" },
             fields: {
               type: "object",
               properties: {
-                sender: fieldSchema,
-                receiver: fieldSchema,
                 transaction: fieldSchema,
               },
-              required: ["sender", "receiver", "transaction"],
+              required: ["transactions"],
             },
           },
           required: ["enabled", "fields"],

--- a/cases-SEP31/util/schema.js
+++ b/cases-SEP31/util/schema.js
@@ -112,7 +112,7 @@ export const infoSchema = {
               properties: {
                 transaction: fieldSchema,
               },
-              required: ["transactions"],
+              required: ["transaction"],
             },
           },
           required: ["enabled", "fields"],

--- a/cases-SEP31/util/sep9-fields.js
+++ b/cases-SEP31/util/sep9-fields.js
@@ -50,8 +50,6 @@ function convertSection(section) {
 
 export function convertSEP31Fields(fieldDef) {
   return {
-    sender: convertSection(fieldDef.sender),
-    receiver: convertSection(fieldDef.receiver),
     transaction: convertSection(fieldDef.transaction),
   };
 }


### PR DESCRIPTION
The new changes to SEP31 updated the schema of the /info endpoint, removing the need for sender/receiver fields, and adding sender_sep12_type and receiver_sep12_type.  This updates the schema, and also adds more detailed logging for the /info endpoint when there is an error.