### PR TITLE
Update SEP31 related end-points.

### DIFF
--- a/cases-SEP31/send.test.js
+++ b/cases-SEP31/send.test.js
@@ -11,7 +11,7 @@ const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
 const testCurrency = process.env.CURRENCY;
 
-describe("POST /send", () => {
+describe("POST /transactions", () => {
   let infoJSON;
   let enabledCurrency;
   let jwt;
@@ -31,7 +31,7 @@ describe("POST /send", () => {
 
   it("fails with no authentication", async () => {
     const { json, status, logs } = await loggableFetch(
-      toml.DIRECT_PAYMENT_SERVER + "/send",
+      toml.DIRECT_PAYMENT_SERVER + "/transactions",
       {
         method: "POST",
         headers: {
@@ -52,7 +52,7 @@ describe("POST /send", () => {
       "Content-Type": "application/json",
     };
     const { json, status, logs } = await loggableFetch(
-      toml.DIRECT_PAYMENT_SERVER + "/send",
+      toml.DIRECT_PAYMENT_SERVER + "/transactions",
       {
         method: "POST",
         headers,
@@ -72,7 +72,7 @@ describe("POST /send", () => {
       "Content-Type": "application/json",
     };
     const { json, status, logs } = await loggableFetch(
-      toml.DIRECT_PAYMENT_SERVER + "/send",
+      toml.DIRECT_PAYMENT_SERVER + "/transactions",
       {
         method: "POST",
         headers,

--- a/cases-SEP31/transaction.test.js
+++ b/cases-SEP31/transaction.test.js
@@ -11,7 +11,7 @@ const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
 const testCurrency = process.env.CURRENCY;
 
-describe("GET /transaction", () => {
+describe("GET /transactions/:id", () => {
   let infoJSON;
   let enabledCurrency;
   let jwt;
@@ -34,7 +34,7 @@ describe("GET /transaction", () => {
       Authorization: `Bearer ${jwt}`,
       "Content-Type": "application/json",
     };
-    const resp = await fetch(toml.DIRECT_PAYMENT_SERVER + "/send", {
+    const resp = await fetch(toml.DIRECT_PAYMENT_SERVER + "/transactions", {
       method: "POST",
       headers: authorizedHeaders,
       body: JSON.stringify({
@@ -53,7 +53,7 @@ describe("GET /transaction", () => {
       status,
       logs,
     } = await loggableFetch(
-      toml.DIRECT_PAYMENT_SERVER + "/transaction?id=23456789",
+      toml.DIRECT_PAYMENT_SERVER + "/transactions/23456789",
       { headers: authorizedHeaders },
     );
     expect(status, logs).toBe(404);
@@ -61,7 +61,7 @@ describe("GET /transaction", () => {
 
   it("should 403 for an unauthenticated request", async () => {
     const resp = await fetch(
-      `${toml.DIRECT_PAYMENT_SERVER}/transaction?id=${transaction.id}`,
+      `${toml.DIRECT_PAYMENT_SERVER}/transactions/${transaction.id}`,
     );
     expect(resp.status).toBe(403);
   });
@@ -72,7 +72,7 @@ describe("GET /transaction", () => {
       logs,
       status,
     } = await loggableFetch(
-      `${toml.DIRECT_PAYMENT_SERVER}/transaction?id=${transaction.id}`,
+      `${toml.DIRECT_PAYMENT_SERVER}/transactions/${transaction.id}`,
       { headers: authorizedHeaders },
     );
     expect(status).toBe(200);


### PR DESCRIPTION
Fixes SEP31 validation.  We need to extend this validator a little bit so it does the right thing when SEP12 is required. 


<img width="1057" alt="Screen Shot 2020-07-31 at 6 09 02 PM" src="https://user-images.githubusercontent.com/21772/89087236-37cdb680-d359-11ea-9c31-ee689b9ca488.png">
