### PR TITLE
Create transaction history order test

### DIFF
--- a/cases-SEP24/transactions.test.js
+++ b/cases-SEP24/transactions.test.js
@@ -145,6 +145,39 @@ describe("Transactions", () => {
     expect(json.transactions.length, logs).toBe(1);
   });
 
+  it("returns a transactions in decending order", async () => {
+    await createTransaction({
+      currency: enabledCurrency,
+      account: keyPair.publicKey(),
+      toml: toml,
+      jwt: jwt,
+      isDeposit: true,
+    });
+    await createTransaction({
+      currency: enabledCurrency,
+      account: keyPair.publicKey(),
+      toml: toml,
+      jwt: jwt,
+      isDeposit: true,
+    });
+
+    const { json, status, logs } = await loggableFetch(
+      transferServer + `/transactions?asset_code=${enabledCurrency}`,
+      {
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+      },
+    );
+    let expected = json.transactions.sort((a, b) =>
+      a.started_at > b.started_at ? 1 : -1,
+    );
+    expect(status, logs).toEqual(200);
+    expect(json.error, logs).not.toBeDefined();
+    expect(json.transactions.length, logs).toBeGreaterThanOrEqual(2);
+    expect(json.transactions, logs).toStrictEqual(expected);
+  });
+
   it("return proper transactions with no_older_than param", async () => {
     let { json: transactionJson } = await createTransaction({
       currency: enabledCurrency,

--- a/cases-SEP24/transactions.test.js
+++ b/cases-SEP24/transactions.test.js
@@ -175,6 +175,9 @@ describe("Transactions", () => {
     expect(status, logs).toEqual(200);
     expect(json.error, logs).not.toBeDefined();
     expect(json.transactions.length, logs).toBeGreaterThanOrEqual(2);
+    json.transactions.forEach((transaction) => {
+      expect(typeof transaction.started_at, logs).toStrictEqual("string");
+    });
     json.transactions.forEach((transaction, index) => {
       const exp_trans_id = expected[index].id;
       expect(transaction.id, logs).toStrictEqual(exp_trans_id);

--- a/cases-SEP24/transactions.test.js
+++ b/cases-SEP24/transactions.test.js
@@ -175,7 +175,10 @@ describe("Transactions", () => {
     expect(status, logs).toEqual(200);
     expect(json.error, logs).not.toBeDefined();
     expect(json.transactions.length, logs).toBeGreaterThanOrEqual(2);
-    expect(json.transactions, logs).toStrictEqual(expected);
+    json.transactions.forEach((transaction, index) => {
+      const exp_trans_id = expected[index].id;
+      expect(transaction.id, logs).toStrictEqual(exp_trans_id);
+    });
   });
 
   it("return proper transactions with no_older_than param", async () => {

--- a/cases-SEP24/transactions.test.js
+++ b/cases-SEP24/transactions.test.js
@@ -170,7 +170,7 @@ describe("Transactions", () => {
       },
     );
     let expected = json.transactions.sort((a, b) =>
-      a.started_at > b.started_at ? 1 : -1,
+      a.started_at < b.started_at ? 1 : -1,
     );
     expect(status, logs).toEqual(200);
     expect(json.error, logs).not.toBeDefined();


### PR DESCRIPTION
# Description

Adds test to verify transaction history.

As specified [HERE](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#transaction-history), transactions should be in descending order.

Addresses: (#165)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually verify that the transactions array from endpoint `GET TRANSFER_SERVER_SEP0024/transactions`'s  json response will return the array of transactions in reverse order in which they were created. 
That is, the most recently created transactions first.
ex) `'2020-09-09T23:15:04.213202Z', '2020-09-09T23:15:03.585388Z', …`