### PR TITLE
Add content type condition to "return a proper available more_info_url transaction link" test

### DIFF
--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -118,7 +118,7 @@ describe("Transaction", () => {
     const moreInfo = await fetch(json.transaction.more_info_url);
     expect(moreInfo.status).toEqual(200);
     expect(moreInfo.headers.get("content-type")).toEqual(
-      "text/html; charset=utf-8",
+      expect.stringContaining("text/html"),
     );
   });
 

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -117,6 +117,9 @@ describe("Transaction", () => {
     });
     const moreInfo = await fetch(json.transaction.more_info_url);
     expect(moreInfo.status).toEqual(200);
+    expect(moreInfo.headers.get("content-type")).toEqual(
+      "text/html; charset=utf-8",
+    );
   });
 
   it("returns a proper error with missing params", async () => {


### PR DESCRIPTION
# Description

Adds a content-type condition check to the "more_info_url transaction link" test
This is to ensure that the URL can be rendered via browsers or mobile devices

Addresses: #173 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- `DOMAIN=https://testanchor.stellar.org npx jest --roots=cases-SEP24 -i transactions`