### PR TITLE
172 unnecessary optional memo fields

### DIFF
--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -87,7 +87,7 @@ describe("Transaction", () => {
         "withdraw_anchor_account",
         "withdraw_memo",
         "withdraw_memo_type",
-      ]).not.toEqual(expect.arrayContaining(key));
+      ]).not.toContain(key);
     });
   });
 
@@ -107,9 +107,7 @@ describe("Transaction", () => {
     });
     await checkTransactionResponse({ json: json, isDeposit: false });
     Object.keys(json.transaction).forEach(function(key) {
-      expect(["deposit_memo", "deposit_memo_type"]).not.toEqual(
-        expect.arrayContaining(key),
-      );
+      expect(["deposit_memo", "deposit_memo_type"]).not.toContain(key);
     });
   });
 

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -106,6 +106,11 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: false });
+    Object.keys(json.transaction).forEach(function(key) {
+      expect(["deposit_memo", "deposit_memo_type"]).not.toEqual(
+        expect.arrayContaining(key),
+      );
+    });
   });
 
   it("return a proper available more_info_url transaction link", async () => {

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -82,13 +82,12 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: true });
-    Object.keys(json.transaction).forEach(function(key) {
-      expect([
-        "withdraw_anchor_account",
-        "withdraw_memo",
-        "withdraw_memo_type",
-      ]).not.toContain(key);
-    });
+    const notExpectedJson = json;
+    notExpectedJson.transaction["withdraw_anchor_account"] = null;
+    notExpectedJson.transaction["withdraw_memo"] = null;
+    notExpectedJson.transaction["withdraw_memo_type"] = null;
+    const schema = getTransactionSchema({ isDeposit: true });
+    expect(json).not.toMatchSchema(schema);
   });
 
   it("has the correct object schema for an existing withdrawal transaction", async () => {
@@ -106,9 +105,11 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: false });
-    Object.keys(json.transaction).forEach(function(key) {
-      expect(["deposit_memo", "deposit_memo_type"]).not.toContain(key);
-    });
+    const notExpectedJson = json;
+    notExpectedJson.transaction["deposit_memo"] = null;
+    notExpectedJson.transaction["deposit_memo_type"] = null;
+    const schema = getTransactionSchema({ isDeposit: false });
+    expect(json).not.toMatchSchema(schema);
   });
 
   it("return a proper available more_info_url transaction link", async () => {

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -82,12 +82,6 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: true });
-    const notExpectedJson = json;
-    notExpectedJson.transaction["withdraw_anchor_account"] = null;
-    notExpectedJson.transaction["withdraw_memo"] = null;
-    notExpectedJson.transaction["withdraw_memo_type"] = null;
-    const schema = getTransactionSchema({ isDeposit: true });
-    expect(json).not.toMatchSchema(schema);
   });
 
   it("has the correct object schema for an existing withdrawal transaction", async () => {
@@ -105,11 +99,6 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: false });
-    const notExpectedJson = json;
-    notExpectedJson.transaction["deposit_memo"] = null;
-    notExpectedJson.transaction["deposit_memo_type"] = null;
-    const schema = getTransactionSchema({ isDeposit: false });
-    expect(json).not.toMatchSchema(schema);
   });
 
   it("return a proper available more_info_url transaction link", async () => {

--- a/cases-SEP24/transaction.test.js
+++ b/cases-SEP24/transaction.test.js
@@ -82,6 +82,13 @@ describe("Transaction", () => {
       jwt: jwt,
     });
     await checkTransactionResponse({ json: json, isDeposit: true });
+    Object.keys(json.transaction).forEach(function(key) {
+      expect([
+        "withdraw_anchor_account",
+        "withdraw_memo",
+        "withdraw_memo_type",
+      ]).not.toEqual(expect.arrayContaining(key));
+    });
   });
 
   it("has the correct object schema for an existing withdrawal transaction", async () => {

--- a/cases-SEP24/util/schema.js
+++ b/cases-SEP24/util/schema.js
@@ -48,6 +48,7 @@ const transactionSchema = {
           type: "boolean",
         },
       },
+      additionalProperties: false,
       required: [
         "id",
         "kind",


### PR DESCRIPTION
# Description

- Extends `"has the correct object schema for an existing deposit transaction"` test to check for withdraw fields
- Extends `"has the correct object schema for an existing withdraw transaction"` test to check for deposit fields

Addresses: #172 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `npm run start:dev` Run SEP-24 on testanchor.stellar.org
  - [X] Run SEP-24
  - [ ] Run optional tests
  - [X] DOMAIN testanchor.stellar.org
  - [ ] Run on mainnet
- [X] `DOMAIN=https://testanchor.stellar.org npx jest --roots=cases-SEP24 -i transaction`
- [X] vscode debugger