### PR TITLE
Change logic of setRunOnMainnet

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -54,9 +54,7 @@ function App() {
       setCurrency(currency);
     }
     if (mainnet) {
-      setRunOnMainnet(
-        process.env.MAINNET === "true" || process.env.MAINNET === "1",
-      );
+      setRunOnMainnet(mainnet === "true" || mainnet === "1");
     }
   }, []);
 


### PR DESCRIPTION
# Description

Fix the issue where the mainnet box was not checked if `mainnet=true` is passed as a query string in the url

Addresses: (#166)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `npm run start:dev` Run SEP-24 on testanchor.stellar.org
  - [ ] Run SEP-24
  - [ ] Run optional tests
  - [ ] DOMAIN testanchor.stellar.org
  - [X] Run on mainnet
- [ ] `DOMAIN=https://testanchor.stellar.org npx jest --roots=cases-SEP24 -i transactions`
- [X] vscode debugger