### PR TITLE
177 home domain

### DIFF
--- a/cases-SEP24/info.test.js
+++ b/cases-SEP24/info.test.js
@@ -2,7 +2,6 @@ import getTomlFile from "../util/getTomlFile";
 import { fetch } from "../util/fetchShim";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
-import { loggableFetch } from "../util/loggableFetcher";
 
 jest.setTimeout(30000);
 
@@ -12,20 +11,11 @@ const url = urlBuilder.toString();
 describe("Info", () => {
   let toml;
   let transferServer;
-  let horizonURL;
   beforeAll(async () => {
     try {
       toml = await getTomlFile(url);
     } catch (e) {
       throw "Invalid TOML formatting";
-    }
-    try {
-      horizonURL =
-        process.env.MAINNET === "true" || process.env.MAINNET === "1"
-          ? "https://horizon.stellar.org"
-          : "https://horizon-testnet.stellar.org";
-    } catch (e) {
-      throw "horizonURL cannot be set";
     }
   });
 
@@ -41,15 +31,6 @@ describe("Info", () => {
     );
     expect(optionsCORS, logs).toBe("*");
     expect(otherVerbCORS, logs).toBe("*");
-  });
-
-  it("has home_domain set in the issuer account", async () => {
-    const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
-    const { json, status, logs } = await loggableFetch(query);
-    expect(status, logs).toEqual(200);
-    expect(toml.TRANSFER_SERVER).toEqual(
-      expect.stringContaining(json.home_domain),
-    );
   });
 
   describe("happy path", () => {

--- a/cases-SEP24/info.test.js
+++ b/cases-SEP24/info.test.js
@@ -1,7 +1,8 @@
-import { fetch } from "../util/fetchShim";
 import getTomlFile from "../util/getTomlFile";
+import { fetch } from "../util/fetchShim";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
+import { loggableFetch } from "../util/loggableFetcher";
 
 jest.setTimeout(30000);
 

--- a/cases-SEP24/info.test.js
+++ b/cases-SEP24/info.test.js
@@ -11,11 +11,20 @@ const url = urlBuilder.toString();
 describe("Info", () => {
   let toml;
   let transferServer;
+  let horizonURL;
   beforeAll(async () => {
     try {
       toml = await getTomlFile(url);
     } catch (e) {
       throw "Invalid TOML formatting";
+    }
+    try {
+      horizonURL =
+        process.env.MAINNET === "true" || process.env.MAINNET === "1"
+          ? "https://horizon.stellar.org"
+          : "https://horizon-testnet.stellar.org";
+    } catch (e) {
+      throw "horizonURL cannot be set";
     }
   });
 
@@ -31,6 +40,15 @@ describe("Info", () => {
     );
     expect(optionsCORS, logs).toBe("*");
     expect(otherVerbCORS, logs).toBe("*");
+  });
+
+  it("has home_domain set in the issuer account", async () => {
+    const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
+    const { json, status, logs } = await loggableFetch(query);
+    expect(status, logs).toEqual(200);
+    expect(toml.TRANSFER_SERVER).toEqual(
+      expect.stringContaining(json.home_domain),
+    );
   });
 
   describe("happy path", () => {

--- a/cases-SEP24/toml.test.js
+++ b/cases-SEP24/toml.test.js
@@ -109,10 +109,12 @@ describe("TOML File", () => {
 
     it("has home_domain set in the issuer account", async () => {
       let enabledCurrency;
+      let json;
+      let issuer = false;
       const transferServer =
         toml.TRANSFER_SERVER_SEP0024 || toml.TRANSFER_SERVER;
-      if (process.env.CURRENCY) {
-        enabledCurrency = process.env.CURRENCY;
+      if (testCurrency) {
+        enabledCurrency = testCurrency;
       } else {
         ({ enabledCurrency } = await getActiveCurrency(
           testCurrency,
@@ -122,11 +124,16 @@ describe("TOML File", () => {
       }
       for (const currency of toml.CURRENCIES) {
         if (currency["code"] == enabledCurrency) {
-          const json = await server.loadAccount(currency.issuer);
-          expect(url).toEqual(expect.stringContaining(json.home_domain));
+          issuer = currency.issuer;
           break;
         }
       }
+      expect(
+        issuer,
+        "Cannot find an issuer of the enabled currency.",
+      ).toBeTruthy();
+      json = await server.loadAccount(issuer);
+      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP24/toml.test.js
+++ b/cases-SEP24/toml.test.js
@@ -2,10 +2,17 @@ import { fetch } from "../util/fetchShim";
 import TOML from "toml";
 import { currencySchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
+import { loggableFetch } from "../util/loggableFetcher";
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const testCurrency = process.env.CURRENCY;
 const url = urlBuilder.toString();
+let horizonURL;
+if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
+  horizonURL = "https://horizon.stellar.org";
+} else {
+  horizonURL = "https://horizon-testnet.stellar.org";
+}
 
 describe("TOML File", () => {
   it("exists", async () => {
@@ -94,6 +101,15 @@ describe("TOML File", () => {
           ORG_NAME: expect.any(String),
           ORG_URL: expect.any(String),
         }),
+      );
+    });
+
+    it("has home_domain set in the issuer account", async () => {
+      const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
+      const { json, status, logs } = await loggableFetch(query);
+      expect(status, logs).toEqual(200);
+      expect(toml.TRANSFER_SERVER).toEqual(
+        expect.stringContaining(json.home_domain),
       );
     });
 

--- a/cases-SEP24/toml.test.js
+++ b/cases-SEP24/toml.test.js
@@ -109,11 +109,13 @@ describe("TOML File", () => {
     it("has home_domain set in the issuer account", async () => {
       let json;
       try {
-        json = await server.loadAccount(toml.CURRENCIES[0].issuer);
+        for (const currency of toml.CURRENCIES) {
+          json = await server.loadAccount(currency.issuer);
+          expect(url).toEqual(expect.stringContaining(json.home_domain));
+        }
       } catch (e) {
         throw e;
       }
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP31/info.test.js
+++ b/cases-SEP31/info.test.js
@@ -1,5 +1,5 @@
-import { loggableFetch } from "../util/loggableFetcher";
 import getTomlFile from "./util/getTomlFile";
+import { loggableFetch } from "../util/loggableFetcher";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
 import { getSep10Token } from "../util/sep10";

--- a/cases-SEP31/info.test.js
+++ b/cases-SEP31/info.test.js
@@ -14,19 +14,10 @@ describe("Info", () => {
   let toml;
   let jwt;
   let DIRECT_PAYMENT_SERVER;
-  let horizonURL;
   beforeAll(async () => {
     toml = await getTomlFile(url);
     DIRECT_PAYMENT_SERVER = toml.DIRECT_PAYMENT_SERVER;
     ({ token: jwt } = await getSep10Token(url, keyPair));
-    try {
-      horizonURL =
-        process.env.MAINNET === "true" || process.env.MAINNET === "1"
-          ? "https://horizon.stellar.org"
-          : "https://horizon-testnet.stellar.org";
-    } catch (e) {
-      throw "horizonURL cannot be set";
-    }
   });
 
   it("has a DIRECT_PAYMENT_SERVER in the toml", () => {
@@ -56,15 +47,6 @@ describe("Info", () => {
       logs = response.logs;
       expect(response.status).toEqual(200);
       expect(json).toBeTruthy();
-    });
-
-    it("has home_domain set in the issuer account", async () => {
-      const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
-      const { json, status, logs } = await loggableFetch(query);
-      expect(status, logs).toEqual(200);
-      expect(toml.TRANSFER_SERVER).toEqual(
-        expect.stringContaining(json.home_domain),
-      );
     });
 
     it("has a proper schema", () => {

--- a/cases-SEP31/toml.test.js
+++ b/cases-SEP31/toml.test.js
@@ -1,4 +1,5 @@
 import TOML from "toml";
+import StellarSDK from "stellar-sdk";
 import { fetch } from "../util/fetchShim";
 import { ensureCORS } from "../util/ensureCORS";
 import { loggableFetch } from "../util/loggableFetcher";
@@ -10,6 +11,8 @@ if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
 } else {
   horizonURL = "https://horizon-testnet.stellar.org";
 }
+const server = new StellarSDK.Server(horizonURL);
+jest.setTimeout(100000);
 
 describe("TOML File", () => {
   it("exists", async () => {
@@ -75,12 +78,13 @@ describe("TOML File", () => {
     });
 
     it("has home_domain set in the issuer account", async () => {
-      const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
-      const { json, status, logs } = await loggableFetch(query);
-      expect(status, logs).toEqual(200);
-      expect(toml.TRANSFER_SERVER).toEqual(
-        expect.stringContaining(json.home_domain),
-      );
+      let json;
+      try {
+        json = await server.loadAccount(toml.CURRENCIES[0].issuer);
+      } catch (e) {
+        throw e;
+      }
+      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
   });
 });

--- a/cases-SEP31/toml.test.js
+++ b/cases-SEP31/toml.test.js
@@ -81,8 +81,10 @@ describe("TOML File", () => {
 
     it("has home_domain set in the issuer account", async () => {
       let enabledCurrency;
-      if (process.env.CURRENCY) {
-        enabledCurrency = process.env.CURRENCY;
+      let json;
+      let issuer = false;
+      if (testCurrency) {
+        enabledCurrency = testCurrency;
       } else {
         ({ enabledCurrency } = await getActiveCurrency(
           testCurrency,
@@ -92,11 +94,22 @@ describe("TOML File", () => {
       }
       for (const currency of toml.CURRENCIES) {
         if (currency["code"] == enabledCurrency) {
-          const json = await server.loadAccount(currency.issuer);
-          expect(url).toEqual(expect.stringContaining(json.home_domain));
+          issuer = currency.issuer;
           break;
         }
       }
+      expect(
+        issuer,
+        "Cannot find an issuer of the enabled currency.",
+      ).toBeTruthy();
+      json = await server.loadAccount(issuer);
+      expect(url).toEqual(expect.stringContaining(json.home_domain));
+    });
+
+    it("has no URLs ending in a slash", () => {
+      expect(
+        toml.TRANSFER_SERVER[toml.TRANSFER_SERVER.length - 1] !== "/",
+      ).toBeTruthy();
     });
   });
 });

--- a/cases-SEP31/toml.test.js
+++ b/cases-SEP31/toml.test.js
@@ -80,11 +80,13 @@ describe("TOML File", () => {
     it("has home_domain set in the issuer account", async () => {
       let json;
       try {
-        json = await server.loadAccount(toml.CURRENCIES[0].issuer);
+        for (const currency of toml.CURRENCIES) {
+          json = await server.loadAccount(currency.issuer);
+          expect(url).toEqual(expect.stringContaining(json.home_domain));
+        }
       } catch (e) {
         throw e;
       }
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
   });
 });

--- a/cases-SEP6/info.test.js
+++ b/cases-SEP6/info.test.js
@@ -2,11 +2,16 @@ import { fetch } from "../util/fetchShim";
 import getTomlFile from "../util/getTomlFile";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
+import { getSep10Token } from "../util/sep10";
+import StellarSDK from "stellar-sdk";
+import { loggableFetch } from "../util/loggableFetcher";
 
 jest.setTimeout(30000);
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
+const secret = "SAUOSXXF7ZDO5PKHRFR445DRKZ66Q5HIM2HIPQGWBTUKJZQAOP3VGH3L";
+const keyPair = StellarSDK.Keypair.fromSecret(secret);
 
 describe("Info", () => {
   let toml;
@@ -31,6 +36,13 @@ describe("Info", () => {
     );
     expect(optionsCORS, logs).toBe("*");
     expect(otherVerbCORS, logs).toBe("*");
+  });
+
+  it("has home_domain set in the issuer account", async () => {
+    const horizonUrl = "https://horizon-testnet.stellar.org";
+    const url = horizonUrl + `/accounts/${toml.CURRENCIES[0].issuer}`;
+    const { json, status, logs } = await loggableFetch(url);
+    console.log(json);
   });
 
   describe("happy path", () => {

--- a/cases-SEP6/info.test.js
+++ b/cases-SEP6/info.test.js
@@ -24,7 +24,6 @@ describe("Info", () => {
         process.env.MAINNET === "true" || process.env.MAINNET === "1"
           ? "https://horizon.stellar.org"
           : "https://horizon-testnet.stellar.org";
-      console.log(horizonURL);
     } catch (e) {
       throw "horizonURL cannot be set";
     }
@@ -45,10 +44,12 @@ describe("Info", () => {
   });
 
   it("has home_domain set in the issuer account", async () => {
-    const horizonUrl = "https://horizon-testnet.stellar.org";
-    const url = horizonUrl + `/accounts/${toml.CURRENCIES[0].issuer}`;
-    const { json, status, logs } = await loggableFetch(url);
-    console.log(json);
+    const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
+    const { json, status, logs } = await loggableFetch(query);
+    expect(status, logs).toEqual(200);
+    expect(toml.TRANSFER_SERVER).toEqual(
+      expect.stringContaining(json.home_domain),
+    );
   });
 
   describe("happy path", () => {

--- a/cases-SEP6/info.test.js
+++ b/cases-SEP6/info.test.js
@@ -2,7 +2,6 @@ import { fetch } from "../util/fetchShim";
 import getTomlFile from "../util/getTomlFile";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
-import { loggableFetch } from "../util/loggableFetcher";
 
 jest.setTimeout(30000);
 
@@ -12,20 +11,11 @@ const url = urlBuilder.toString();
 describe("Info", () => {
   let toml;
   let transferServer;
-  let horizonURL;
   beforeAll(async () => {
     try {
       toml = await getTomlFile(url);
     } catch (e) {
       throw "Invalid TOML formatting";
-    }
-    try {
-      horizonURL =
-        process.env.MAINNET === "true" || process.env.MAINNET === "1"
-          ? "https://horizon.stellar.org"
-          : "https://horizon-testnet.stellar.org";
-    } catch (e) {
-      throw "horizonURL cannot be set";
     }
   });
 
@@ -41,15 +31,6 @@ describe("Info", () => {
     );
     expect(optionsCORS, logs).toBe("*");
     expect(otherVerbCORS, logs).toBe("*");
-  });
-
-  it("has home_domain set in the issuer account", async () => {
-    const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
-    const { json, status, logs } = await loggableFetch(query);
-    expect(status, logs).toEqual(200);
-    expect(toml.TRANSFER_SERVER).toEqual(
-      expect.stringContaining(json.home_domain),
-    );
   });
 
   describe("happy path", () => {

--- a/cases-SEP6/info.test.js
+++ b/cases-SEP6/info.test.js
@@ -2,25 +2,31 @@ import { fetch } from "../util/fetchShim";
 import getTomlFile from "../util/getTomlFile";
 import { infoSchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
-import { getSep10Token } from "../util/sep10";
-import StellarSDK from "stellar-sdk";
 import { loggableFetch } from "../util/loggableFetcher";
 
 jest.setTimeout(30000);
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const url = urlBuilder.toString();
-const secret = "SAUOSXXF7ZDO5PKHRFR445DRKZ66Q5HIM2HIPQGWBTUKJZQAOP3VGH3L";
-const keyPair = StellarSDK.Keypair.fromSecret(secret);
 
 describe("Info", () => {
   let toml;
   let transferServer;
+  let horizonURL;
   beforeAll(async () => {
     try {
       toml = await getTomlFile(url);
     } catch (e) {
       throw "Invalid TOML formatting";
+    }
+    try {
+      horizonURL =
+        process.env.MAINNET === "true" || process.env.MAINNET === "1"
+          ? "https://horizon.stellar.org"
+          : "https://horizon-testnet.stellar.org";
+      console.log(horizonURL);
+    } catch (e) {
+      throw "horizonURL cannot be set";
     }
   });
 

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -111,8 +111,10 @@ describe("TOML File", () => {
 
     it("has home_domain set in the issuer account", async () => {
       let enabledCurrency;
-      if (process.env.CURRENCY) {
-        enabledCurrency = process.env.CURRENCY;
+      let json;
+      let issuer = false;
+      if (testCurrency) {
+        enabledCurrency = testCurrency;
       } else {
         ({ enabledCurrency } = await getActiveCurrency(
           testCurrency,
@@ -122,11 +124,16 @@ describe("TOML File", () => {
       }
       for (const currency of toml.CURRENCIES) {
         if (currency["code"] == enabledCurrency) {
-          const json = await server.loadAccount(currency.issuer);
-          expect(url).toEqual(expect.stringContaining(json.home_domain));
+          issuer = currency.issuer;
           break;
         }
       }
+      expect(
+        issuer,
+        "Cannot find an issuer of the enabled currency.",
+      ).toBeTruthy();
+      json = await server.loadAccount(issuer);
+      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -3,6 +3,7 @@ import StellarSDK from "stellar-sdk";
 import { fetch } from "../util/fetchShim";
 import { currencySchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
+import { getActiveCurrency } from "../util/currency";
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const testCurrency = process.env.CURRENCY;
@@ -109,14 +110,22 @@ describe("TOML File", () => {
     });
 
     it("has home_domain set in the issuer account", async () => {
-      let json;
-      try {
-        for (const currency of toml.CURRENCIES) {
-          json = await server.loadAccount(currency.issuer);
+      let enabledCurrency;
+      if (process.env.CURRENCY) {
+        enabledCurrency = process.env.CURRENCY;
+      } else {
+        ({ enabledCurrency } = await getActiveCurrency(
+          testCurrency,
+          toml.TRANSFER_SERVER,
+          false,
+        ));
+      }
+      for (const currency of toml.CURRENCIES) {
+        if (currency["code"] == enabledCurrency) {
+          const json = await server.loadAccount(currency.issuer);
           expect(url).toEqual(expect.stringContaining(json.home_domain));
+          break;
         }
-      } catch (e) {
-        throw e;
       }
     });
 

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -2,11 +2,17 @@ import { fetch } from "../util/fetchShim";
 import TOML from "toml";
 import { currencySchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
-import { JsonWebTokenError } from "jsonwebtoken";
+import { loggableFetch } from "../util/loggableFetcher";
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const testCurrency = process.env.CURRENCY;
 const url = urlBuilder.toString();
+let horizonURL;
+if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
+  horizonURL = "https://horizon.stellar.org";
+} else {
+  horizonURL = "https://horizon-testnet.stellar.org";
+}
 
 jest.setTimeout(100000);
 
@@ -99,6 +105,15 @@ describe("TOML File", () => {
           ORG_NAME: expect.any(String),
           ORG_URL: expect.any(String),
         }),
+      );
+    });
+
+    it("has home_domain set in the issuer account", async () => {
+      const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
+      const { json, status, logs } = await loggableFetch(query);
+      expect(status, logs).toEqual(200);
+      expect(toml.TRANSFER_SERVER).toEqual(
+        expect.stringContaining(json.home_domain),
       );
     });
 

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -88,7 +88,7 @@ describe("TOML File", () => {
       it("selected currency is available", () => {
         expect(
           toml.CURRENCIES,
-          "The currency you selectd isn't available in the TOML file.",
+          "The currency you selected isn't available in the TOML file.",
         ).toEqual(
           expect.arrayContaining([
             expect.objectContaining({

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -1,8 +1,8 @@
-import { fetch } from "../util/fetchShim";
 import TOML from "toml";
+import StellarSDK from "stellar-sdk";
+import { fetch } from "../util/fetchShim";
 import { currencySchema } from "./util/schema";
 import { ensureCORS } from "../util/ensureCORS";
-import { loggableFetch } from "../util/loggableFetcher";
 
 const urlBuilder = new URL(process.env.DOMAIN);
 const testCurrency = process.env.CURRENCY;
@@ -13,7 +13,7 @@ if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
 } else {
   horizonURL = "https://horizon-testnet.stellar.org";
 }
-
+const server = new StellarSDK.Server(horizonURL);
 jest.setTimeout(100000);
 
 describe("TOML File", () => {
@@ -109,12 +109,13 @@ describe("TOML File", () => {
     });
 
     it("has home_domain set in the issuer account", async () => {
-      const query = horizonURL + `/accounts/${toml.CURRENCIES[0].issuer}`;
-      const { json, status, logs } = await loggableFetch(query);
-      expect(status, logs).toEqual(200);
-      expect(toml.TRANSFER_SERVER).toEqual(
-        expect.stringContaining(json.home_domain),
-      );
+      let json;
+      try {
+        json = await server.loadAccount(toml.CURRENCIES[0].issuer);
+      } catch (e) {
+        throw e;
+      }
+      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -111,11 +111,13 @@ describe("TOML File", () => {
     it("has home_domain set in the issuer account", async () => {
       let json;
       try {
-        json = await server.loadAccount(toml.CURRENCIES[0].issuer);
+        for (const currency of toml.CURRENCIES) {
+          json = await server.loadAccount(currency.issuer);
+          expect(url).toEqual(expect.stringContaining(json.home_domain));
+        }
       } catch (e) {
         throw e;
       }
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
     });
 
     it("has no URLs ending in a slash", () => {


### PR DESCRIPTION
# Description

Check if the issuer account has the following
- "home_domain" key value
- "home_domain"'s value is the same as the given domain where the stellar.toml will be searched for at the following location:
`https://DOMAIN/.well-known/stellar.toml`

Note: 
~I've added these tests to each SEP group test's `info.test.js` mostly because it seemed the most appropriate.~

Updates:
- I moved the tests into the `toml.test.js` tests because its more closely related to toml related requirements than /info endpoint's requirements
- ~I compare and check if every currency's issuer has the correct home_domain value.~
- I only compare and check if the active currency's issuer has the correct home_domain value.

Addresses issue: (177)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `npm run start:dev`
  - [X] Run SEP-6
  - [X] Run SEP-24
  - [X] Run SEP-31
  - [X] Run optional tests
  - [X] DOMAIN testanchor.stellar.org
  - [X] DOMAIN https://finclusive.com
  - [X] Run on mainnet
- [X] `DOMAIN=https://testanchor.stellar.org npx jest -i toml`
- [X] vscode debugger