### PR TITLE
Home domain patch

### DIFF
--- a/cases-SEP24/toml.test.js
+++ b/cases-SEP24/toml.test.js
@@ -133,7 +133,13 @@ describe("TOML File", () => {
         "Cannot find an issuer of the enabled currency.",
       ).toBeTruthy();
       json = await server.loadAccount(issuer);
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      const homeDomain = json.home_domain
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(homeDomain).toEqual(expectedDomain);
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP24/toml.test.js
+++ b/cases-SEP24/toml.test.js
@@ -107,7 +107,7 @@ describe("TOML File", () => {
       );
     });
 
-    it("has home_domain set in the issuer account", async () => {
+    it("has the correct home_domain set", async () => {
       let enabledCurrency;
       let json;
       let issuer = false;

--- a/cases-SEP31/toml.test.js
+++ b/cases-SEP31/toml.test.js
@@ -103,7 +103,13 @@ describe("TOML File", () => {
         "Cannot find an issuer of the enabled currency.",
       ).toBeTruthy();
       json = await server.loadAccount(issuer);
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      const homeDomain = json.home_domain
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(homeDomain).toEqual(expectedDomain);
     });
 
     it("has no URLs ending in a slash", () => {

--- a/cases-SEP31/toml.test.js
+++ b/cases-SEP31/toml.test.js
@@ -79,7 +79,7 @@ describe("TOML File", () => {
       ).toBeTruthy();
     });
 
-    it("has home_domain set in the issuer account", async () => {
+    it("has the correct home_domain set", async () => {
       let enabledCurrency;
       let json;
       let issuer = false;

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -109,7 +109,7 @@ describe("TOML File", () => {
       );
     });
 
-    it("has home_domain set in the issuer account", async () => {
+    it("has the correct home_domain set", async () => {
       let enabledCurrency;
       let json;
       let issuer = false;

--- a/cases-SEP6/toml.test.js
+++ b/cases-SEP6/toml.test.js
@@ -133,7 +133,13 @@ describe("TOML File", () => {
         "Cannot find an issuer of the enabled currency.",
       ).toBeTruthy();
       json = await server.loadAccount(issuer);
-      expect(url).toEqual(expect.stringContaining(json.home_domain));
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      const homeDomain = json.home_domain
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(homeDomain).toEqual(expectedDomain);
     });
 
     it("has no URLs ending in a slash", () => {


### PR DESCRIPTION
# Description

- update `has home_domain set in the issuer account` test name to be `has the correct home_domain set`
- make DOMAIN comparison more strict

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ X] `npm run start:dev`
  - [X] Run SEP-6
  - [X] Run SEP-24
  - [X] Run SEP-31
  - [ ] Run optional tests
  - [X] DOMAIN testanchor.stellar.org
  - [ ] Run on mainnet
- [X] `DOMAIN=https://testanchor.stellar.org npx jest
  - [X]  `--roots=cases-SEP6-i toml`
  - [X]  `--roots=cases-SEP24 -i toml`
  - [X]  `--roots=cases-SEP31 -i toml`
- [X] vscode debugger