### PR TITLE
Add SEP-10 2.0 challenge

### DIFF
--- a/cases-SEP24/sep10.test.js
+++ b/cases-SEP24/sep10.test.js
@@ -177,6 +177,22 @@ describe("SEP10", () => {
       expect(tx.source, logs).toBe(toml.SIGNING_KEY);
     });
 
+    it("returns SEP-10 2.0 challenge", async () => {
+      expect(json.error, logs).toBeFalsy();
+      expect(json.transaction, logs).toBeTruthy();
+      const tx = new StellarSDK.Transaction(
+        json.transaction,
+        networkPassphrase,
+      );
+      expect(tx.operations, logs).toHaveLength(1);
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(tx.operations[0].name, logs).toEqual(
+        expect.stringContaining(expectedDomain),
+      );
+    });
+
     describe("POST Response", () => {
       it("Accepts application/x-www-form-urlencoded", async () => {
         const tx = new StellarSDK.Transaction(

--- a/cases-SEP31/sep10.test.js
+++ b/cases-SEP31/sep10.test.js
@@ -117,6 +117,22 @@ describe("SEP10", () => {
       expect(tx.source, logs).toBe(toml.SIGNING_KEY);
     });
 
+    it("returns SEP-10 2.0 challenge", async () => {
+      expect(json.error, logs).toBeFalsy();
+      expect(json.transaction, logs).toBeTruthy();
+      const tx = new StellarSDK.Transaction(
+        json.transaction,
+        networkPassphrase,
+      );
+      expect(tx.operations, logs).toHaveLength(1);
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(tx.operations[0].name, logs).toEqual(
+        expect.stringContaining(expectedDomain),
+      );
+    });
+
     describe("POST Response", () => {
       let tokenJson;
       let logs;

--- a/cases-SEP6/sep10.test.js
+++ b/cases-SEP6/sep10.test.js
@@ -177,6 +177,22 @@ describe("SEP10", () => {
       expect(tx.source, logs).toBe(toml.SIGNING_KEY);
     });
 
+    it("returns SEP-10 2.0 challenge", async () => {
+      expect(json.error, logs).toBeFalsy();
+      expect(json.transaction, logs).toBeTruthy();
+      const tx = new StellarSDK.Transaction(
+        json.transaction,
+        networkPassphrase,
+      );
+      expect(tx.operations, logs).toHaveLength(1);
+      const expectedDomain = url
+        .replace(/(^\w+:|^\/$)\/\//, "")
+        .replace(/(\/.*?$)/, "");
+      expect(tx.operations[0].name, logs).toEqual(
+        expect.stringContaining(expectedDomain),
+      );
+    });
+
     describe("POST Response", () => {
       it("Accepts application/x-www-form-urlencoded", async () => {
         const tx = new StellarSDK.Transaction(


### PR DESCRIPTION
# Description

Add a test to ensure anchors are adhering to SEP 10 2.0 challenge response requirements.

This means that the tx operations name (or key) includes a fully qualified domain name.
https://github.com/stellar/stellar-protocol/commit/28c636b4ef5074ca0c3d46bbe9bf0f3f38095233#diff-72480d0894ae2d1a31c229b64ad4c37bR100
 
Addresses issue: (#180)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] `npm run start:dev`
  - [X] Run SEP-6
  - [X] Run SEP-24
  - [X] Run SEP-31
  - [] Run optional tests
  - [X] DOMAIN testanchor.stellar.org
  - [] Run on mainnet
- [X] `DOMAIN=https://testanchor.stellar.org npx jest
  - [X]  `--roots=cases-SEP6-i sep10`
  - [X]  `--roots=cases-SEP24 -i sep10`
  - [X]  `--roots=cases-SEP31 -i sep10`
- [X] vscode debugger