### PR TITLE
Conditional to skip test if on mainnet

### DIFF
--- a/cases-SEP24/sep10.test.js
+++ b/cases-SEP24/sep10.test.js
@@ -20,6 +20,7 @@ const keyPair = StellarSDK.Keypair.fromSecret(secret);
 let horizonURL;
 let masterAccount = {};
 let networkPassphrase;
+let skip = (condition) => (condition ? xit : it);
 if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
   masterAccount.kp = StellarSDK.Keypair.fromSecret(
     process.env.MAINNET_MASTER_SECRET_KEY,
@@ -443,81 +444,84 @@ describe("SEP10", () => {
      * with the same key hoping the server doesn't de-duplicate signers, and
      * count its weight twice.
      */
-    it("fails when trying to reuse the same signer to gain weight", async () => {
-      const userAccount = getAccount();
-      const signerAccount = getAccount();
-      let builder = new StellarSDK.TransactionBuilder(userAccount.data, {
-        fee: StellarSDK.BASE_FEE * 5,
-        networkPassphrase: networkPassphrase,
-      })
-        .addOperation(
-          StellarSDK.Operation.setOptions({
-            lowThreshold: 2,
-            medThreshold: 2,
-            highThreshold: 2,
-            signer: {
-              ed25519PublicKey: signerAccount.kp.publicKey(),
-              weight: 1,
-            },
-          }),
-        )
-        .setTimeout(30);
-      let transaction = builder.build();
-      transaction.sign(userAccount.kp);
-      try {
-        await server.submitTransaction(transaction);
-      } catch (e) {
-        await resubmitOnRecoverableFailure(
-          e.response.data,
-          userAccount.kp,
-          [userAccount.kp],
-          builder,
-          server,
-        );
-      }
-      let token, logs;
-      try {
-        ({ token, logs } = await getSep10Token(url, userAccount.kp, [
-          signerAccount.kp,
-          signerAccount.kp,
-        ]));
-      } catch (e) {
-        // we need to do cleanup, but token and logs must be truthy to make
-        // sure test fails when an exception is raised here.
-        token = logs =
-          "an error occurred when attempting to retrieve SEP10 token";
-      }
-      // Reduce thresholds back to 1 so master signer can sign alone again
-      if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-        builder = new StellarSDK.TransactionBuilder(userAccount.data, {
+    skip(process.env.MAINNET === "true" || process.env.MAINNET === "1")(
+      "fails when trying to reuse the same signer to gain weight",
+      async () => {
+        const userAccount = getAccount();
+        const signerAccount = getAccount();
+        let builder = new StellarSDK.TransactionBuilder(userAccount.data, {
           fee: StellarSDK.BASE_FEE * 5,
           networkPassphrase: networkPassphrase,
         })
           .addOperation(
             StellarSDK.Operation.setOptions({
-              lowThreshold: 1,
-              medThreshold: 1,
-              highThreshold: 1,
+              lowThreshold: 2,
+              medThreshold: 2,
+              highThreshold: 2,
+              signer: {
+                ed25519PublicKey: signerAccount.kp.publicKey(),
+                weight: 1,
+              },
             }),
           )
           .setTimeout(30);
-        let lowerThresholdsTx = builder.build();
-        // Need both signatures to reach current threshold
-        lowerThresholdsTx.sign(signerAccount.kp, userAccount.kp);
+        let transaction = builder.build();
+        transaction.sign(userAccount.kp);
         try {
-          await server.submitTransaction(lowerThresholdsTx);
+          await server.submitTransaction(transaction);
         } catch (e) {
           await resubmitOnRecoverableFailure(
             e.response.data,
             userAccount.kp,
-            [userAccount.kp, signerAccount.kp],
+            [userAccount.kp],
             builder,
             server,
           );
         }
-      }
-      expect(token, logs).toBeFalsy();
-    });
+        let token, logs;
+        try {
+          ({ token, logs } = await getSep10Token(url, userAccount.kp, [
+            signerAccount.kp,
+            signerAccount.kp,
+          ]));
+        } catch (e) {
+          // we need to do cleanup, but token and logs must be truthy to make
+          // sure test fails when an exception is raised here.
+          token = logs =
+            "an error occurred when attempting to retrieve SEP10 token";
+        }
+        // Reduce thresholds back to 1 so master signer can sign alone again
+        if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
+          builder = new StellarSDK.TransactionBuilder(userAccount.data, {
+            fee: StellarSDK.BASE_FEE * 5,
+            networkPassphrase: networkPassphrase,
+          })
+            .addOperation(
+              StellarSDK.Operation.setOptions({
+                lowThreshold: 1,
+                medThreshold: 1,
+                highThreshold: 1,
+              }),
+            )
+            .setTimeout(30);
+          let lowerThresholdsTx = builder.build();
+          // Need both signatures to reach current threshold
+          lowerThresholdsTx.sign(signerAccount.kp, userAccount.kp);
+          try {
+            await server.submitTransaction(lowerThresholdsTx);
+          } catch (e) {
+            await resubmitOnRecoverableFailure(
+              e.response.data,
+              userAccount.kp,
+              [userAccount.kp, signerAccount.kp],
+              builder,
+              server,
+            );
+          }
+        }
+        expect(token, logs).toBeFalsy();
+      },
+    );
 
     it("succeeds with multiple signers", async () => {
       const userAccount = getAccount();

--- a/cases-SEP24/sep10.test.js
+++ b/cases-SEP24/sep10.test.js
@@ -20,6 +20,8 @@ const keyPair = StellarSDK.Keypair.fromSecret(secret);
 let horizonURL;
 let masterAccount = {};
 let networkPassphrase;
+let skip =
+  process.env.MAINNET === "true" || process.env.MAINNET === "1" ? xit : it;
 if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
   masterAccount.kp = StellarSDK.Keypair.fromSecret(
     process.env.MAINNET_MASTER_SECRET_KEY,
@@ -326,7 +328,7 @@ describe("SEP10", () => {
      * no longer sign for itself.  This should mean that it can't
      * get a token with its own signature.
      */
-    it("fails for an account that can't sign for itself", async () => {
+    skip("fails for an account that can't sign for itself", async () => {
       const account = getAccount();
       const tmpSigner = StellarSDK.Keypair.random();
       let builder = new StellarSDK.TransactionBuilder(account.data, {

--- a/cases-SEP6/sep10.test.js
+++ b/cases-SEP6/sep10.test.js
@@ -20,6 +20,7 @@ const keyPair = StellarSDK.Keypair.fromSecret(secret);
 let horizonURL;
 let masterAccount = {};
 let networkPassphrase;
+let skip = (condition) => (condition ? xit : it);
 if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
   masterAccount.kp = StellarSDK.Keypair.fromSecret(
     process.env.MAINNET_MASTER_SECRET_KEY,
@@ -328,78 +329,83 @@ describe("SEP10", () => {
      * no longer sign for itself.  This should mean that it can't
      * get a token with its own signature.
      */
-    it("fails for an account that can't sign for itself", async () => {
-      const account = getAccount();
-      const tmpSigner = StellarSDK.Keypair.random();
-      let builder = new StellarSDK.TransactionBuilder(account.data, {
-        fee: StellarSDK.BASE_FEE * 5,
-        networkPassphrase: networkPassphrase,
-      })
-        .addOperation(
-          StellarSDK.Operation.setOptions({
-            // Add a new signer so we can create a transaction to add the
-            // original signer back after test.
-            signer: {
-              ed25519PublicKey: tmpSigner.publicKey(),
-              weight: 1,
-            },
-            masterWeight: 0,
-            lowThreshold: 1,
-            medThreshold: 1,
-            highThreshold: 1,
-          }),
-        )
-        .setTimeout(30);
-      let transaction = builder.build();
-      transaction.sign(account.kp);
-      try {
-        await server.submitTransaction(transaction);
-      } catch (e) {
-        await resubmitOnRecoverableFailure(
-          e.response.data,
-          account.kp,
-          [account.kp],
-          builder,
-          server,
-        );
-      }
-      let token, logs;
-      try {
-        ({ token, logs } = await getSep10Token(url, account.kp, [account.kp]));
-      } catch (e) {
-        // We need to do cleanup so we can't let the test fail here.
-        // The test expects 'token' to be falsy, so make it non-falsy
-        token = logs =
-          "an error occurred when attempting to retrieve SEP10 token";
-      }
-      // Add original signer back so the account can be merged, if using mainnet
-      if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-        builder = new StellarSDK.TransactionBuilder(account.data, {
+    skip(process.env.MAINNET === "true" || process.env.MAINNET === "1")(
+      "fails for an account that can't sign for itself",
+      async () => {
+        const account = getAccount();
+        const tmpSigner = StellarSDK.Keypair.random();
+        let builder = new StellarSDK.TransactionBuilder(account.data, {
           fee: StellarSDK.BASE_FEE * 5,
           networkPassphrase: networkPassphrase,
         })
           .addOperation(
             StellarSDK.Operation.setOptions({
-              masterWeight: 1,
+              // Add a new signer so we can create a transaction to add the
+              // original signer back after test.
+              signer: {
+                ed25519PublicKey: tmpSigner.publicKey(),
+                weight: 1,
+              },
+              masterWeight: 0,
+              lowThreshold: 1,
+              medThreshold: 1,
+              highThreshold: 1,
             }),
           )
           .setTimeout(30);
-        let addBackSignerTx = builder.build();
-        addBackSignerTx.sign(tmpSigner);
+        let transaction = builder.build();
+        transaction.sign(account.kp);
         try {
-          await server.submitTransaction(addBackSignerTx);
+          await server.submitTransaction(transaction);
         } catch (e) {
           await resubmitOnRecoverableFailure(
             e.response.data,
             account.kp,
-            [tmpSigner],
+            [account.kp],
             builder,
             server,
           );
         }
-      }
-      expect(token, logs).toBeFalsy();
-    });
+        let token, logs;
+        try {
+          ({ token, logs } = await getSep10Token(url, account.kp, [
+            account.kp,
+          ]));
+        } catch (e) {
+          // We need to do cleanup so we can't let the test fail here.
+          // The test expects 'token' to be falsy, so make it non-falsy
+          token = logs =
+            "an error occurred when attempting to retrieve SEP10 token";
+        }
+        // Add original signer back so the account can be merged, if using mainnet
+        if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
+          builder = new StellarSDK.TransactionBuilder(account.data, {
+            fee: StellarSDK.BASE_FEE * 5,
+            networkPassphrase: networkPassphrase,
+          })
+            .addOperation(
+              StellarSDK.Operation.setOptions({
+                masterWeight: 1,
+              }),
+            )
+            .setTimeout(30);
+          let addBackSignerTx = builder.build();
+          addBackSignerTx.sign(tmpSigner);
+          try {
+            await server.submitTransaction(addBackSignerTx);
+          } catch (e) {
+            await resubmitOnRecoverableFailure(
+              e.response.data,
+              account.kp,
+              [tmpSigner],
+              builder,
+              server,
+            );
+          }
+        }
+        expect(token, logs).toBeFalsy();
+      },
+    );
 
     it("succeeds for a signer of an account", async () => {
       const userAccount = getAccount();

--- a/cases-SEP6/sep10.test.js
+++ b/cases-SEP6/sep10.test.js
@@ -20,6 +20,8 @@ const keyPair = StellarSDK.Keypair.fromSecret(secret);
 let horizonURL;
 let masterAccount = {};
 let networkPassphrase;
+let skip =
+  process.env.MAINNET === "true" || process.env.MAINNET === "1" ? xit : it;
 if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
   masterAccount.kp = StellarSDK.Keypair.fromSecret(
     process.env.MAINNET_MASTER_SECRET_KEY,
@@ -328,7 +330,7 @@ describe("SEP10", () => {
      * no longer sign for itself.  This should mean that it can't
      * get a token with its own signature.
      */
-    it("fails for an account that can't sign for itself", async () => {
+    skip("fails for an account that can't sign for itself", async () => {
       const account = getAccount();
       const tmpSigner = StellarSDK.Keypair.random();
       let builder = new StellarSDK.TransactionBuilder(account.data, {


### PR DESCRIPTION
This is a bit of leak patching while we figure out the xlm leak.

If you want tests to be skipped if its running on mainnet replace `it` with `skip(process.env.MAINNET === "true" || process.env.MAINNET === "1")`