### PR TITLE
load accounts from env var ACCOUNTPOOLSECRETS

### DIFF
--- a/cases-SEP24/sep10.test.js
+++ b/cases-SEP24/sep10.test.js
@@ -46,17 +46,17 @@ const getAccount = (function() {
   };
 })();
 
+async function loadAccountPool (secrests) {
+  for (const sk of secrests) {
+    let kp = StellarSDK.Keypair.fromSecret(sk)
+    let data = await server.loadAccount(kp.publicKey())
+    accountPool.push({ kp: kp, data: data });
+  }
+}
 beforeAll(async () => {
   if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-    let kps = [];
-    for (let i = 0; i < 10; i++) kps.push(StellarSDK.Keypair.random());
-    masterAccount.data = await server.loadAccount(masterAccount.kp.publicKey());
-    accountPool = await createAccountsFrom(
-      masterAccount,
-      kps,
-      server,
-      networkPassphrase,
-    );
+    let secrests = process.env.ACCOUNTPOOLSECRETS.split(",");
+    await loadAccountPool(secrests)
   } else {
     for (let i = 0; i < 10; i++) {
       accountPool.push({ kp: StellarSDK.Keypair.random(), data: null });

--- a/cases-SEP6/sep10.test.js
+++ b/cases-SEP6/sep10.test.js
@@ -46,18 +46,19 @@ const getAccount = (function() {
   };
 })();
 
+async function loadAccountPool (secrests) {
+  for (const sk of secrests) {
+    let kp = StellarSDK.Keypair.fromSecret(sk)
+    let data = await server.loadAccount(kp.publicKey())
+    accountPool.push({ kp: kp, data: data });
+  }
+}
+
 beforeAll(async () => {
   if (process.env.MAINNET === "true" || process.env.MAINNET === "1") {
-    let kps = [];
-    for (let i = 0; i < 10; i++) kps.push(StellarSDK.Keypair.random());
-    masterAccount.data = await server.loadAccount(masterAccount.kp.publicKey());
-    accountPool = await createAccountsFrom(
-      masterAccount,
-      kps,
-      server,
-      networkPassphrase,
-    );
-  } else {
+    let secrests = process.env.ACCOUNTPOOLSECRETS.split(",");
+    await loadAccountPool(secrests)
+    } else {
     for (let i = 0; i < 10; i++) {
       accountPool.push({ kp: StellarSDK.Keypair.random(), data: null });
     }


### PR DESCRIPTION
# Description

Problem: Whenever transfer-server-validator fails/crashes after we create on demand accounts but before we merge them back into the master account we lose access to those accounts.

Solution: Replaces the on demand create account logic in the SEP10 test with pre-funded accounts via `ACCOUNTPOOLSECRETS` env variable

Addresses issue: #191 

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

 - add a comma delimitated string with 10 prefunded account secret keys as an env var 
     - `export ACCOUNTPOOLSECRETS="S...,S...,etc` 
 - run validator suite with an anchor that is mainnet compatible